### PR TITLE
Uniform transfer process

### DIFF
--- a/pallets/assets/src/benchmarking.rs
+++ b/pallets/assets/src/benchmarking.rs
@@ -210,6 +210,38 @@ benchmarks! {
         assert_last_event::<T>(Event::Burn(caller, USDT.into(), 100_u32.into()).into())
     }
 
+    force_burn {
+        add_assets::<T>(100)?;
+        let caller = alice::<T>();
+        frame_system::Pallet::<T>::inc_providers(&caller);
+        Assets::<T>::register_asset_id(
+            caller.clone(),
+            USDT.into(),
+            AssetSymbol(b"USDT".to_vec()),
+            AssetName(b"USDT".to_vec()),
+            DEFAULT_BALANCE_PRECISION,
+            Balance::zero(),
+            true,
+            None,
+            None,
+        ).unwrap();
+        Assets::<T>::mint(
+            RawOrigin::Signed(caller.clone()).into(),
+            USDT.into(),
+            caller.clone(),
+            1000_u32.into()
+        ).unwrap();
+    }: _(
+        RawOrigin::Root,
+        USDT.into(),
+        caller.clone(),
+        100_u32.into()
+    )
+    verify {
+        let usdt_issuance = Assets::<T>::total_issuance(&USDT.into())?;
+        assert_eq!(usdt_issuance, 900_u32.into());
+    }
+
     set_non_mintable {
         add_assets::<T>(100)?;
         let caller = alice::<T>();
@@ -249,6 +281,7 @@ mod tests {
             assert_ok!(Pallet::<Runtime>::test_benchmark_mint());
             assert_ok!(Pallet::<Runtime>::test_benchmark_force_mint());
             assert_ok!(Pallet::<Runtime>::test_benchmark_burn());
+            assert_ok!(Pallet::<Runtime>::test_benchmark_force_burn());
             assert_ok!(Pallet::<Runtime>::test_benchmark_set_non_mintable());
         });
     }

--- a/pallets/assets/src/tests.rs
+++ b/pallets/assets/src/tests.rs
@@ -41,6 +41,7 @@ mod tests {
         ASSET_DESCRIPTION_MAX_LENGTH, DEFAULT_BALANCE_PRECISION, DOT, VAL, XOR,
     };
     use frame_support::assert_noop;
+    use frame_support::error::BadOrigin;
     use frame_support::{assert_err, assert_ok};
     use hex_literal::hex;
     use sp_runtime::traits::Zero;
@@ -581,6 +582,47 @@ mod tests {
             assert_eq!(
                 Assets::free_balance(&XOR, &BOB).expect("Failed to query free balance."),
                 Balance::from(0u32)
+            );
+        })
+    }
+
+    #[test]
+    fn should_force_burn_correctly() {
+        let mut ext = ExtBuilder::default().build();
+        ext.execute_with(|| {
+            assert_ok!(Assets::register_asset_id(
+                ALICE,
+                XOR,
+                AssetSymbol(b"XOR".to_vec()),
+                AssetName(b"SORA".to_vec()),
+                DEFAULT_BALANCE_PRECISION,
+                Balance::from(10u32),
+                true,
+                None,
+                None,
+            ));
+            assert_ok!(Assets::mint_to(&XOR, &ALICE, &BOB, Balance::from(100u32)));
+            assert_eq!(
+                Assets::free_balance(&XOR, &BOB).expect("Failed to query free balance."),
+                Balance::from(100u32)
+            );
+            assert_ok!(Assets::force_burn(
+                Origin::root(),
+                XOR,
+                BOB,
+                Balance::from(10u32)
+            ));
+            assert_eq!(
+                Assets::free_balance(&XOR, &BOB).expect("Failed to query free balance."),
+                Balance::from(90u32)
+            );
+            assert_err!(
+                Assets::force_burn(Origin::signed(ALICE), XOR, BOB, Balance::from(10u32)),
+                BadOrigin
+            );
+            assert_eq!(
+                Assets::free_balance(&XOR, &BOB).expect("Failed to query free balance."),
+                Balance::from(90u32)
             );
         })
     }

--- a/pallets/assets/src/weights.rs
+++ b/pallets/assets/src/weights.rs
@@ -57,70 +57,70 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
+use common::weights::constants::EXTRINSIC_FIXED_WEIGHT;
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
-use common::weights::constants::EXTRINSIC_FIXED_WEIGHT;
 
 /// Weight functions for `assets`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
-	// Storage: System Account (r:1 w:1)
-	// Storage: Assets AssetOwners (r:1 w:1)
-	// Storage: Permissions Owners (r:2 w:2)
-	// Storage: Permissions Permissions (r:2 w:1)
-	// Storage: Assets AssetInfos (r:0 w:1)
-	fn register() -> Weight {
-		(116_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(6 as Weight))
-	}
-	fn transfer() -> Weight {
-		(22_000_000 as Weight)
-	}
-	// Storage: Assets AssetInfos (r:1 w:0)
-	// Storage: Permissions Permissions (r:1 w:0)
-	// Storage: Tokens Accounts (r:1 w:1)
-	// Storage: Tokens TotalIssuance (r:1 w:1)
-	// Storage: System Account (r:1 w:1)
-	fn mint() -> Weight {
-		(71_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-	}
-	// Storage: Tokens Accounts (r:1 w:1)
-	// Storage: Tokens TotalIssuance (r:1 w:1)
-	// Storage: System Account (r:1 w:1)
-	fn force_mint() -> Weight {
-		(49_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-	}
-	// Storage: Tokens Accounts (r:1 w:1)
-	// Storage: Tokens TotalIssuance (r:1 w:1)
-	fn burn() -> Weight {
-		(48_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-	}
-	// Storage: Assets AssetOwners (r:1 w:0)
-	// Storage: Assets AssetInfos (r:1 w:1)
-	fn set_non_mintable() -> Weight {
-		(35_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	// This part was generated separately:
-	// DATE: 2023-02-13, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
-	// HOSTNAME: `sora2-test-b1`, CPU: `AMD EPYC 7571`
-	// EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("dev"), DB CACHE: 1024
-	
-	// Storage: Tokens Accounts (r:1 w:1)
-	// Storage: Tokens TotalIssuance (r:1 w:1)
-	fn force_burn() -> Weight {
-		(132_081_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-	}
+    // Storage: System Account (r:1 w:1)
+    // Storage: Assets AssetOwners (r:1 w:1)
+    // Storage: Permissions Owners (r:2 w:2)
+    // Storage: Permissions Permissions (r:2 w:1)
+    // Storage: Assets AssetInfos (r:0 w:1)
+    fn register() -> Weight {
+        (116_000_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(6 as Weight))
+            .saturating_add(T::DbWeight::get().writes(6 as Weight))
+    }
+    fn transfer() -> Weight {
+        (22_000_000 as Weight)
+    }
+    // Storage: Assets AssetInfos (r:1 w:0)
+    // Storage: Permissions Permissions (r:1 w:0)
+    // Storage: Tokens Accounts (r:1 w:1)
+    // Storage: Tokens TotalIssuance (r:1 w:1)
+    // Storage: System Account (r:1 w:1)
+    fn mint() -> Weight {
+        (71_000_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(5 as Weight))
+            .saturating_add(T::DbWeight::get().writes(3 as Weight))
+    }
+    // Storage: Tokens Accounts (r:1 w:1)
+    // Storage: Tokens TotalIssuance (r:1 w:1)
+    // Storage: System Account (r:1 w:1)
+    fn force_mint() -> Weight {
+        (49_000_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(3 as Weight))
+            .saturating_add(T::DbWeight::get().writes(3 as Weight))
+    }
+    // Storage: Tokens Accounts (r:1 w:1)
+    // Storage: Tokens TotalIssuance (r:1 w:1)
+    fn burn() -> Weight {
+        (48_000_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(2 as Weight))
+            .saturating_add(T::DbWeight::get().writes(2 as Weight))
+    }
+    // Storage: Assets AssetOwners (r:1 w:0)
+    // Storage: Assets AssetInfos (r:1 w:1)
+    fn set_non_mintable() -> Weight {
+        (35_000_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(2 as Weight))
+            .saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
+    // This part was generated separately:
+    // DATE: 2023-02-13, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
+    // HOSTNAME: `sora2-test-b1`, CPU: `AMD EPYC 7571`
+    // EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("dev"), DB CACHE: 1024
+
+    // Storage: Tokens Accounts (r:1 w:1)
+    // Storage: Tokens TotalIssuance (r:1 w:1)
+    fn force_burn() -> Weight {
+        (132_081_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(2 as Weight))
+            .saturating_add(T::DbWeight::get().writes(2 as Weight))
+    }
 }
 
 impl crate::WeightInfo for () {
@@ -140,9 +140,9 @@ impl crate::WeightInfo for () {
         EXTRINSIC_FIXED_WEIGHT
     }
     fn set_non_mintable() -> Weight {
-		EXTRINSIC_FIXED_WEIGHT
+        EXTRINSIC_FIXED_WEIGHT
     }
-	fn force_burn() -> Weight {
-		EXTRINSIC_FIXED_WEIGHT
-	}
+    fn force_burn() -> Weight {
+        EXTRINSIC_FIXED_WEIGHT
+    }
 }

--- a/pallets/assets/src/weights.rs
+++ b/pallets/assets/src/weights.rs
@@ -102,20 +102,24 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	// TODO: benchmark on reference hardware
-	// Storage: Tokens Accounts (r:1 w:1)
-	// Storage: Tokens TotalIssuance (r:1 w:1)
-	fn force_burn() -> Weight {
-		(43_500_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-	}
 	// Storage: Assets AssetOwners (r:1 w:0)
 	// Storage: Assets AssetInfos (r:1 w:1)
 	fn set_non_mintable() -> Weight {
 		(35_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// This part was generated separately:
+	// DATE: 2023-02-13, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
+	// HOSTNAME: `sora2-test-b1`, CPU: `AMD EPYC 7571`
+	// EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("dev"), DB CACHE: 1024
+	
+	// Storage: Tokens Accounts (r:1 w:1)
+	// Storage: Tokens TotalIssuance (r:1 w:1)
+	fn force_burn() -> Weight {
+		(132_081_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 }
 
@@ -135,10 +139,10 @@ impl crate::WeightInfo for () {
     fn burn() -> Weight {
         EXTRINSIC_FIXED_WEIGHT
     }
-    fn force_burn() -> Weight {
-        EXTRINSIC_FIXED_WEIGHT
-    }
     fn set_non_mintable() -> Weight {
-        EXTRINSIC_FIXED_WEIGHT
+		EXTRINSIC_FIXED_WEIGHT
     }
+	fn force_burn() -> Weight {
+		EXTRINSIC_FIXED_WEIGHT
+	}
 }

--- a/pallets/assets/src/weights.rs
+++ b/pallets/assets/src/weights.rs
@@ -102,6 +102,14 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
+	// TODO: benchmark on reference hardware
+	// Storage: Tokens Accounts (r:1 w:1)
+	// Storage: Tokens TotalIssuance (r:1 w:1)
+	fn force_burn() -> Weight {
+		(43_500_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
 	// Storage: Assets AssetOwners (r:1 w:0)
 	// Storage: Assets AssetInfos (r:1 w:1)
 	fn set_non_mintable() -> Weight {
@@ -125,6 +133,9 @@ impl crate::WeightInfo for () {
         EXTRINSIC_FIXED_WEIGHT
     }
     fn burn() -> Weight {
+        EXTRINSIC_FIXED_WEIGHT
+    }
+    fn force_burn() -> Weight {
         EXTRINSIC_FIXED_WEIGHT
     }
     fn set_non_mintable() -> Weight {

--- a/runtime/src/extensions.rs
+++ b/runtime/src/extensions.rs
@@ -164,7 +164,7 @@ mod tests {
     use common::{balance, VAL, XOR};
 
     use crate::extensions::ChargeTransactionPayment;
-    use crate::{Call, Runtime};
+    use crate::{Call, GetBaseAssetId, Runtime};
 
     #[test]
     fn check_calls_from_bridge_peers_pays_yes() {
@@ -205,9 +205,10 @@ mod tests {
 
     #[test]
     fn simple_call_should_pass() {
-        let call = Call::Balances(pallet_balances::Call::transfer {
-            dest: From::from([1; 32]),
-            value: balance!(100),
+        let call = Call::Assets(assets::Call::transfer {
+            asset_id: GetBaseAssetId::get(),
+            to: From::from([1; 32]),
+            amount: balance!(100),
         });
 
         assert!(call.check_for_swap_in_batch().is_ok());
@@ -216,14 +217,16 @@ mod tests {
     #[test]
     fn regular_batch_should_pass() {
         let batch_calls = vec![
-            pallet_balances::Call::transfer {
-                dest: From::from([1; 32]),
-                value: balance!(100),
+            assets::Call::transfer {
+                asset_id: GetBaseAssetId::get(),
+                to: From::from([1; 32]),
+                amount: balance!(100),
             }
             .into(),
-            pallet_balances::Call::transfer {
-                dest: From::from([1; 32]),
-                value: balance!(100),
+            assets::Call::transfer {
+                asset_id: GetBaseAssetId::get(),
+                to: From::from([1; 32]),
+                amount: balance!(100),
             }
             .into(),
         ];
@@ -239,9 +242,10 @@ mod tests {
 
     fn test_swap_in_batch(call: Call) {
         let batch_calls = vec![
-            pallet_balances::Call::transfer {
-                dest: From::from([1; 32]),
-                value: balance!(100),
+            assets::Call::transfer {
+                asset_id: GetBaseAssetId::get(),
+                to: From::from([1; 32]),
+                amount: balance!(100),
             }
             .into(),
             call,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1861,7 +1861,7 @@ construct_runtime! {
         // Non-native tokens - everything apart of XOR.
         Tokens: tokens::{Pallet, Storage, Config<T>, Event<T>} = 18,
         // Unified interface for XOR and non-native tokens.
-        Currencies: currencies::{Pallet, Call} = 19,
+        Currencies: currencies::{Pallet} = 19,
         TradingPair: trading_pair::{Pallet, Call, Storage, Config<T>, Event<T>} = 20,
         Assets: assets::{Pallet, Call, Storage, Config<T>, Event<T>} = 21,
         DEXManager: dex_manager::{Pallet, Storage, Config<T>} = 22,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1838,7 +1838,7 @@ construct_runtime! {
 
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent} = 1,
         // Balances in native currency - XOR.
-        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 2,
+        Balances: pallet_balances::{Pallet, Storage, Config<T>, Event<T>} = 2,
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 3,
         RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage} = 4,
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage} = 5,

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -30,9 +30,9 @@
 
 use crate::mock::{ensure_pool_initialized, fill_spot_price};
 use crate::{
-    AccountId, AssetId, Assets, Balance, Balances, Call, Currencies, GetXorFeeAccountId, Origin,
-    PoolXYK, Referrals, ReferrerWeight, Runtime, SoraParliamentShare, Staking, System, Tokens,
-    Weight, XorBurnedWeight, XorFee, XorIntoValBurnedWeight,
+    AccountId, AssetId, Assets, Balance, Balances, Call, Currencies, GetBaseAssetId,
+    GetXorFeeAccountId, Origin, PoolXYK, Referrals, ReferrerWeight, Runtime, SoraParliamentShare,
+    Staking, System, Tokens, Weight, XorBurnedWeight, XorFee, XorIntoValBurnedWeight,
 };
 use common::mock::{alice, bob, charlie};
 use common::prelude::constants::{BIG_FEE, SMALL_FEE};
@@ -355,9 +355,10 @@ fn custom_fees_work() {
 
         // An extrinsic without manual fee adjustment
         let call: &<Runtime as frame_system::Config>::Call =
-            &Call::Balances(pallet_balances::Call::transfer {
-                dest: bob(),
-                value: TRANSFER_AMOUNT,
+            &Call::Assets(assets::Call::transfer {
+                asset_id: GetBaseAssetId::get(),
+                to: bob(),
+                amount: TRANSFER_AMOUNT,
             });
 
         let pre = ChargeTransactionPayment::<Runtime>::from(0u128.into())
@@ -480,9 +481,10 @@ fn normal_fees_multiplied() {
         let balance_after_fee_withdrawal = FixedWrapper::from(INITIAL_BALANCE);
         // An extrinsic without custom fee adjustment
         let call: &<Runtime as frame_system::Config>::Call =
-            &Call::Balances(pallet_balances::Call::transfer {
-                dest: bob(),
-                value: TRANSFER_AMOUNT,
+            &Call::Assets(assets::Call::transfer {
+                asset_id: GetBaseAssetId::get(),
+                to: bob(),
+                amount: TRANSFER_AMOUNT,
             });
 
         let pre = ChargeTransactionPayment::<Runtime>::from(0u128.into())

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -30,9 +30,9 @@
 
 use crate::mock::{ensure_pool_initialized, fill_spot_price};
 use crate::{
-    AccountId, AssetId, Assets, Balance, Balances, Call, Currencies, GetBaseAssetId,
-    GetXorFeeAccountId, Origin, PoolXYK, Referrals, ReferrerWeight, Runtime, SoraParliamentShare,
-    Staking, System, Tokens, Weight, XorBurnedWeight, XorFee, XorIntoValBurnedWeight,
+    AccountId, AssetId, Assets, Balance, Balances, Call, Currencies, GetXorFeeAccountId, Origin,
+    PoolXYK, Referrals, ReferrerWeight, Runtime, SoraParliamentShare, Staking, System, Tokens,
+    Weight, XorBurnedWeight, XorFee, XorIntoValBurnedWeight,
 };
 use common::mock::{alice, bob, charlie};
 use common::prelude::constants::{BIG_FEE, SMALL_FEE};
@@ -355,10 +355,8 @@ fn custom_fees_work() {
 
         // An extrinsic without manual fee adjustment
         let call: &<Runtime as frame_system::Config>::Call =
-            &Call::Assets(assets::Call::transfer {
-                asset_id: GetBaseAssetId::get(),
-                to: bob(),
-                amount: TRANSFER_AMOUNT,
+            &Call::OracleProxy(oracle_proxy::Call::enable_oracle {
+                oracle: common::Oracle::BandChainFeed,
             });
 
         let pre = ChargeTransactionPayment::<Runtime>::from(0u128.into())

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -481,10 +481,8 @@ fn normal_fees_multiplied() {
         let balance_after_fee_withdrawal = FixedWrapper::from(INITIAL_BALANCE);
         // An extrinsic without custom fee adjustment
         let call: &<Runtime as frame_system::Config>::Call =
-            &Call::Assets(assets::Call::transfer {
-                asset_id: GetBaseAssetId::get(),
-                to: bob(),
-                amount: TRANSFER_AMOUNT,
+            &Call::OracleProxy(oracle_proxy::Call::enable_oracle {
+                oracle: common::Oracle::BandChainFeed,
             });
 
         let pre = ChargeTransactionPayment::<Runtime>::from(0u128.into())


### PR DESCRIPTION
#146 <- more details here
- In order to have uniform transfer (which is through `assets.transfer` extrinsic), we remove direct calls to pallets `balances` and `currencies`.
- Not to lose functionality of often-used `currencies.set_balance`, extrinsic `assets.force_burn` was added.
- Appropriate changes to tests/benchmarks were made