### PR TITLE
docs (docker compose): update `docker compose` to V2 in readme

### DIFF
--- a/bridge-docker/Dockerfile.hardhat
+++ b/bridge-docker/Dockerfile.hardhat
@@ -6,4 +6,5 @@ COPY ethereum-bridge-contracts/yarn.lock /app
 RUN yarn
 
 COPY ethereum-bridge-contracts /app
+COPY ethereum-bridge-contracts/env.template /app/.env
 COPY bridge-docker/hardhat/deploy.sh /app/docker-deploy.sh

--- a/bridge-docker/README.md
+++ b/bridge-docker/README.md
@@ -3,7 +3,7 @@
 ### Run EVM bridge
 
 ```
-docker-compose up -f docker-compose.sora.yml -f docker-compose.evm.yml -d --build
+docker compose -f docker-compose.sora.yml -f docker-compose.evm.yml up -d --build
 ```
 
 ### Run substrate bridge
@@ -11,25 +11,25 @@ docker-compose up -f docker-compose.sora.yml -f docker-compose.evm.yml -d --buil
 Assume you have cloned [parachain repo](https://github.com/sora-xor/sora2-parachain) in `../sora2-parachain`
 
 ```
-docker-compose up -f docker-compose.sora.yml -f docker-compose.parachain.yml -f ../sora2-parachain/bridge-docker/docker-compose.yml -d --build
+docker compose -f docker-compose.sora.yml -f docker-compose.parachain.yml -f ../sora2-parachain/bridge-docker/docker-compose.yml up -d --build
 ```
 
 ### Run both bridges
 
 ```
-docker-compose up -f docker-compose.sora.yml -f docker-compose.evm.yml -f docker-compose.parachain.yml -f ../sora2-parachain/bridge-docker/docker-compose.yml -d --build
+docker compose -f docker-compose.sora.yml -f docker-compose.evm.yml -f docker-compose.parachain.yml -f ../sora2-parachain/bridge-docker/docker-compose.yml up -d --build
 ```
 
 ### Stop
 
 ```
-docker-compose down <-f args>
+docker compose <-f args> down
 ```
 
 ### Stop and remove volumes
 
 ```
-docker-compose down <-f args> -v 
+docker compose <-f args> down -v 
 ```
 
 ### Update cached dependencies


### PR DESCRIPTION
docker compose V1 support ends in June 2023, it is better to use latest V2 (https://docs.docker.com/compose/compose-v2/#:~:text=From%20the%20end%20of%20June,from%20all%20Docker%20Desktop%20versions) 

 - replaced  `docker-compose` (v1) with `docker compose` (v2)
 - added `.env` for hardhat