### PR TITLE
Fix/Swap transfer batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ cargo build --release --features private-net
 ./run_script.sh -d -w -r
 ```
 access running network via polkadot.js/apps (select Development -> Local Node, e.g. [link](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer))
+#### On macOS
+macOS is shipped with the BSD version of `getopt`. If the script behaves incorrectly and does not parse arguments,  
+make sure you have installed and set as active the GNU versions of `awk` and `getopt`.
+
 
 ### Run benchmarks to generate weights
 > For release must be run on hardware matching validator requirements specification.

--- a/pallets/liquidity-proxy/benchmarking/src/lib.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/lib.rs
@@ -556,7 +556,7 @@ benchmarks! {
 
             receivers.into_iter().for_each(|batch| {
                 let BatchReceiverInfo {account_id, target_amount} = batch;
-                assert_eq!(Assets::<T>::free_balance(&asset_id, &account_id).unwrap(), target_amount);
+                assert_eq!(Assets::<T>::free_balance(&outcome_asset_id, &account_id).unwrap(), target_amount);
             })
         });
     }

--- a/pallets/liquidity-proxy/benchmarking/src/lib.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/lib.rs
@@ -465,7 +465,7 @@ benchmarks! {
         let caller = alice::<T>();
         let caller_origin: <T as frame_system::Config>::Origin = RawOrigin::Signed(caller.clone()).into();
 
-        let mut swap_batches: Vec<SwapBatchInfo<T>> = Vec::new();
+        let mut swap_batches: Vec<SwapBatchInfo<T::AssetId, T::DEXId, T::AccountId>> = Vec::new();
         setup_benchmark::<T>()?;
         for i in 0..n {
             let raw_asset_id = [[3u8; 28].to_vec(), i.to_be_bytes().to_vec()]
@@ -529,7 +529,7 @@ benchmarks! {
                 balance!(10000),
                 balance!(10000),
             ).expect("Failed to deposit liquidity");
-            let recv_batch: Vec<BatchReceiverInfo<T>> = (0..k).into_iter().map(|recv_num| {
+            let recv_batch: Vec<BatchReceiverInfo<T::AccountId>> = (0..k).into_iter().map(|recv_num| {
                 let account_id = generic_account::<T>(i, recv_num);
                 let target_amount = balance!(0.1);
                 BatchReceiverInfo {account_id, target_amount}

--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -1509,6 +1509,30 @@ impl<T: Config> std::fmt::Debug for BatchReceiverInfo<T> {
     }
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Eq, PartialOrd, Ord, scale_info::TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct SwapBatchInfo<T: Config> {
+    pub outcome_asset_id: T::AssetId,
+    pub dex_id: T::DEXId,
+    pub receivers: Vec<BatchReceiverInfo<T>>,
+}
+
+impl<T: Config> SwapBatchInfo<T> {
+    pub fn len(&self) -> usize {
+        self.receivers.len()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: Config> std::fmt::Debug for SwapBatchInfo<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "SwapBatchInfo {{ asset_id: {:?}, dex_id: {:?}, receivers: {:?}, }}",
+            self.outcome_asset_id, self.dex_id, self.receivers
+        ))
+    }
+}
+
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
@@ -1633,28 +1657,29 @@ pub mod pallet {
             Ok(().into())
         }
 
-        /// Dispatches multiple swap & transfer operations. `receivers` holds info about desired out amount and
-        /// its associated account per asset id
+        /// Dispatches multiple swap & transfer operations. `swap_batches` contains vector of
+        /// SwapBatchInfo structs, where each batch specifies which asset ID and DEX ID should
+        /// be used for swapping, receiver accounts and their desired outcome amount in asset,
+        /// specified for the current batch.
         ///
         /// - `origin`: the account on whose behalf the transaction is being executed,
-        /// - `receivers`: the ordered map, which maps the asset id being bought to the vector of batch receivers
-        /// - `dex_id`: DEX ID for which liquidity sources aggregation is being done,
+        /// - `swap_batches`: the vector containing the SwapBatchInfo structs,
         /// - `input_asset_id`: ID of the asset being sold,
         /// - `max_input_amount`: the maximum amount to be sold in input_asset_id,
-        /// - `selected_source_types`: list of selected LiquiditySource types, selection effect is determined by filter_mode,
+        /// - `selected_source_types`: list of selected LiquiditySource types, selection effect is
+        ///                            determined by filter_mode,
         /// - `filter_mode`: indicate either to allow or forbid selected types only, or disable filtering.
         #[transactional]
         #[pallet::weight(<T as Config>::WeightInfo::swap_transfer_batch(
-                receivers.len() as u32,
-                receivers.iter()
-                    .map(|(_, recv_batch)| recv_batch.len() as u32)
+                swap_batches.len() as u32,
+                swap_batches.iter()
+                    .map(|batch| batch.len() as u32)
                     .sum()
             )
         )]
         pub fn swap_transfer_batch(
             origin: OriginFor<T>,
-            receivers: Vec<(T::AssetId, Vec<BatchReceiverInfo<T>>)>,
-            dex_id: T::DEXId,
+            swap_batches: Vec<SwapBatchInfo<T>>,
             input_asset_id: T::AssetId,
             mut max_input_amount: Balance,
             selected_source_types: Vec<LiquiditySourceType>,
@@ -1662,15 +1687,21 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
-            let filter = LiquiditySourceFilter::with_mode(
-                dex_id,
-                filter_mode.clone(),
-                selected_source_types.clone(),
-            );
-
             let mut unique_asset_ids: BTreeSet<T::AssetId> = BTreeSet::new();
-            fallible_iterator::convert(receivers.into_iter().map(|val| Ok(val))).for_each(
-                |(asset_id, recv_batch)| {
+            fallible_iterator::convert(swap_batches.into_iter().map(|val| Ok(val))).for_each(
+                |swap_batch_info| {
+                    let SwapBatchInfo {
+                        outcome_asset_id: asset_id,
+                        dex_id,
+                        receivers,
+                    } = swap_batch_info;
+
+                    let filter = LiquiditySourceFilter::with_mode(
+                        dex_id,
+                        filter_mode.clone(),
+                        selected_source_types.clone(),
+                    );
+
                     if Self::is_forbidden_filter(
                         &input_asset_id,
                         &asset_id,
@@ -1684,7 +1715,7 @@ pub mod pallet {
                         Err(Error::<T>::AggregationError)?
                     }
 
-                    let out_amount = recv_batch.iter().map(|recv| recv.target_amount).sum();
+                    let out_amount = receivers.iter().map(|recv| recv.target_amount).sum();
                     Self::inner_exchange(
                         dex_id,
                         &who,
@@ -1702,7 +1733,7 @@ pub mod pallet {
                         .ok_or(Error::<T>::SlippageNotTolerated)?;
 
                     let mut unique_batch_receivers: BTreeSet<T::AccountId> = BTreeSet::new();
-                    fallible_iterator::convert(recv_batch.into_iter().map(|val| Ok(val))).for_each(
+                    fallible_iterator::convert(receivers.into_iter().map(|val| Ok(val))).for_each(
                         |receiver| {
                             if !unique_batch_receivers.insert(receiver.account_id.clone()) {
                                 Err(Error::<T>::AggregationError)?

--- a/pallets/liquidity-proxy/src/tests.rs
+++ b/pallets/liquidity-proxy/src/tests.rs
@@ -29,7 +29,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mock::*;
-use crate::{BatchReceiverInfo, Error, QuoteInfo};
+use crate::{BatchReceiverInfo, Error, SwapBatchInfo};
 use common::prelude::fixnum::ops::CheckedSub;
 use common::prelude::{AssetName, AssetSymbol, Balance, QuoteAmount, SwapAmount};
 use common::{
@@ -311,9 +311,7 @@ fn test_quote_exact_output_base_should_pass() {
 fn test_poly_quote_exact_input_1_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &KSM,
             &DOT,
@@ -359,9 +357,7 @@ fn test_poly_quote_exact_input_1_should_pass() {
 fn test_poly_quote_exact_output_1_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &KSM,
             &DOT,
@@ -407,9 +403,7 @@ fn test_poly_quote_exact_output_1_should_pass() {
 fn test_poly_quote_exact_input_2_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &DOT,
             &KSM,
@@ -455,9 +449,7 @@ fn test_poly_quote_exact_input_2_should_pass() {
 fn test_poly_quote_exact_output_2_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &DOT,
             &KSM,
@@ -896,9 +888,7 @@ fn test_fee_when_exchange_on_one_source_of_many_should_pass() {
             ]
             .into(),
         );
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_C_ID,
             &GetBaseAssetId::get(),
             &DOT,
@@ -1576,7 +1566,7 @@ fn test_quote_should_return_rewards_for_multiple_sources() {
         MockLiquiditySource3::add_reward((balance!(301), DOT.into(), RewardReason::Unspecified));
 
         let amount: Balance = balance!(500);
-        let QuoteInfo { rewards, .. } = LiquidityProxy::inner_quote(
+        let (_, rewards, _) = LiquidityProxy::inner_quote(
             DEX_C_ID,
             &GetBaseAssetId::get(),
             &DOT,
@@ -2790,9 +2780,7 @@ fn test_quote_with_no_price_impact_with_desired_input() {
         ));
 
         // Buying KSM for VAL
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_D_ID,
             &VAL,
             &KSM,
@@ -2896,9 +2884,7 @@ fn test_quote_with_no_price_impact_with_desired_output() {
         ));
 
         // Buying KSM for VAL
-        let QuoteInfo {
-            outcome: quotes, ..
-        } = LiquidityProxy::inner_quote(
+        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
             DEX_D_ID,
             &VAL,
             &KSM,
@@ -2909,60 +2895,6 @@ fn test_quote_with_no_price_impact_with_desired_output() {
         )
         .expect("Failed to get a quote");
         assert_approx_eq!(quotes.amount, amount_val_in, balance!(100));
-    });
-}
-
-#[test]
-fn test_quote_returns_correct_path() {
-    let mut ext = ExtBuilder::default().build();
-    ext.execute_with(|| {
-        MockMCBCPool::init(get_mcbc_reserves_normal()).unwrap();
-        let filter = LiquiditySourceFilter::with_allowed(
-            DEX_D_ID,
-            [
-                LiquiditySourceType::MulticollateralBondingCurvePool,
-                LiquiditySourceType::MockPool,
-            ]
-            .to_vec(),
-        );
-        let amount_val_in = balance!(45547);
-        let amount_xor_intermediate = balance!(200);
-        let amount_ksm_out = balance!(174);
-        // Buying XOR for VAL, expecting direct VAL -> XOR conversion
-        let QuoteInfo {
-            outcome: quotes,
-            path,
-            ..
-        } = LiquidityProxy::inner_quote(
-            DEX_D_ID,
-            &VAL,
-            &XOR,
-            QuoteAmount::with_desired_output(amount_xor_intermediate),
-            filter.clone(),
-            false,
-            true,
-        )
-        .expect("Failed to get a quote");
-        assert_approx_eq!(quotes.amount, amount_val_in, balance!(100));
-        assert_eq!(path, vec![VAL, XOR]);
-
-        // Buying KSM for VAL, expecting VAL -> XOR -> KSM conversion
-        let QuoteInfo {
-            outcome: quotes,
-            path,
-            ..
-        } = LiquidityProxy::inner_quote(
-            DEX_D_ID,
-            &VAL,
-            &KSM,
-            QuoteAmount::with_desired_output(amount_ksm_out),
-            filter.clone(),
-            false,
-            true,
-        )
-        .expect("Failed to get a quote");
-        assert_approx_eq!(quotes.amount, amount_val_in, balance!(100));
-        assert_eq!(path, vec![VAL, XOR, KSM]);
     });
 }
 
@@ -3251,16 +3183,20 @@ fn test_batch_swap_successful() {
         assert_ok!(LiquidityProxy::swap_transfer_batch(
             Origin::signed(alice()),
             Vec::from([
-                (USDT, vec![BatchReceiverInfo::new(bob(), balance!(10))],),
-                (
-                    KSM,
-                    vec![
+                SwapBatchInfo {
+                    outcome_asset_id: USDT,
+                    dex_id: DEX_C_ID,
+                    receivers: vec![BatchReceiverInfo::new(bob(), balance!(10))]
+                },
+                SwapBatchInfo {
+                    outcome_asset_id: KSM,
+                    dex_id: DEX_A_ID,
+                    receivers: vec![
                         BatchReceiverInfo::new(charlie(), balance!(10)),
                         BatchReceiverInfo::new(dave(), balance!(10)),
                     ]
-                ),
+                },
             ]),
-            DEX_A_ID,
             XOR,
             balance!(100),
             [LiquiditySourceType::XYKPool].to_vec(),
@@ -3287,16 +3223,20 @@ fn test_batch_swap_desired_input_successful() {
         assert_ok!(LiquidityProxy::swap_transfer_batch(
             Origin::signed(alice()),
             Vec::from([
-                (USDT, vec![BatchReceiverInfo::new(bob(), balance!(10))],),
-                (
-                    KSM,
-                    vec![
+                SwapBatchInfo {
+                    outcome_asset_id: USDT,
+                    dex_id: DEX_C_ID,
+                    receivers: vec![BatchReceiverInfo::new(bob(), balance!(10))]
+                },
+                SwapBatchInfo {
+                    outcome_asset_id: KSM,
+                    dex_id: DEX_A_ID,
+                    receivers: vec![
                         BatchReceiverInfo::new(charlie(), balance!(10)),
                         BatchReceiverInfo::new(dave(), balance!(10)),
                     ]
-                ),
+                },
             ]),
-            DEX_A_ID,
             XOR,
             balance!(32),
             [LiquiditySourceType::XYKPool].to_vec(),
@@ -3324,16 +3264,20 @@ fn test_batch_swap_desired_input_too_low() {
             LiquidityProxy::swap_transfer_batch(
                 Origin::signed(alice()),
                 Vec::from([
-                    (USDT, vec![BatchReceiverInfo::new(bob(), balance!(10))],),
-                    (
-                        KSM,
-                        vec![
+                    SwapBatchInfo {
+                        outcome_asset_id: USDT,
+                        dex_id: DEX_C_ID,
+                        receivers: vec![BatchReceiverInfo::new(bob(), balance!(10))]
+                    },
+                    SwapBatchInfo {
+                        outcome_asset_id: KSM,
+                        dex_id: DEX_A_ID,
+                        receivers: vec![
                             BatchReceiverInfo::new(charlie(), balance!(10)),
                             BatchReceiverInfo::new(dave(), balance!(10)),
                         ]
-                    ),
+                    },
                 ]),
-                DEX_A_ID,
                 XOR,
                 balance!(1),
                 [LiquiditySourceType::XYKPool].to_vec(),
@@ -3356,17 +3300,25 @@ fn test_batch_swap_fail_with_duplicate_asset_ids() {
             LiquidityProxy::swap_transfer_batch(
                 Origin::signed(alice()),
                 Vec::from([
-                    (USDT, vec![BatchReceiverInfo::new(bob(), balance!(10))],),
-                    (
-                        KSM,
-                        vec![
+                    SwapBatchInfo {
+                        outcome_asset_id: USDT,
+                        dex_id: DEX_C_ID,
+                        receivers: vec![BatchReceiverInfo::new(bob(), balance!(10))]
+                    },
+                    SwapBatchInfo {
+                        outcome_asset_id: USDT,
+                        dex_id: DEX_A_ID,
+                        receivers: vec![BatchReceiverInfo::new(bob(), balance!(10))]
+                    },
+                    SwapBatchInfo {
+                        outcome_asset_id: KSM,
+                        dex_id: DEX_A_ID,
+                        receivers: vec![
                             BatchReceiverInfo::new(charlie(), balance!(10)),
                             BatchReceiverInfo::new(dave(), balance!(10)),
                         ]
-                    ),
-                    (USDT, vec![BatchReceiverInfo::new(bob(), balance!(10))],),
+                    },
                 ]),
-                DEX_A_ID,
                 XOR,
                 balance!(100),
                 [LiquiditySourceType::XYKPool].to_vec(),
@@ -3389,17 +3341,21 @@ fn test_batch_swap_fail_with_duplicate_receivers_within_asset_id() {
             LiquidityProxy::swap_transfer_batch(
                 Origin::signed(alice()),
                 Vec::from([
-                    (USDT, vec![BatchReceiverInfo::new(bob(), balance!(10))],),
-                    (
-                        KSM,
-                        vec![
+                    SwapBatchInfo {
+                        outcome_asset_id: USDT,
+                        dex_id: DEX_C_ID,
+                        receivers: vec![BatchReceiverInfo::new(bob(), balance!(10))]
+                    },
+                    SwapBatchInfo {
+                        outcome_asset_id: KSM,
+                        dex_id: DEX_A_ID,
+                        receivers: vec![
                             BatchReceiverInfo::new(charlie(), balance!(10)),
                             BatchReceiverInfo::new(dave(), balance!(10)),
                             BatchReceiverInfo::new(dave(), balance!(10)),
                         ]
-                    ),
+                    },
                 ]),
-                DEX_A_ID,
                 XOR,
                 balance!(100),
                 [LiquiditySourceType::XYKPool].to_vec(),

--- a/pallets/liquidity-proxy/src/tests.rs
+++ b/pallets/liquidity-proxy/src/tests.rs
@@ -29,7 +29,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mock::*;
-use crate::{BatchReceiverInfo, Error, SwapBatchInfo};
+use crate::{BatchReceiverInfo, Error, QuoteInfo, SwapBatchInfo};
 use common::prelude::fixnum::ops::CheckedSub;
 use common::prelude::{AssetName, AssetSymbol, Balance, QuoteAmount, SwapAmount};
 use common::{
@@ -311,7 +311,9 @@ fn test_quote_exact_output_base_should_pass() {
 fn test_poly_quote_exact_input_1_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &KSM,
             &DOT,
@@ -357,7 +359,9 @@ fn test_poly_quote_exact_input_1_should_pass() {
 fn test_poly_quote_exact_output_1_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &KSM,
             &DOT,
@@ -403,7 +407,9 @@ fn test_poly_quote_exact_output_1_should_pass() {
 fn test_poly_quote_exact_input_2_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &DOT,
             &KSM,
@@ -449,7 +455,9 @@ fn test_poly_quote_exact_input_2_should_pass() {
 fn test_poly_quote_exact_output_2_should_pass() {
     let mut ext = ExtBuilder::default().build();
     ext.execute_with(|| {
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_A_ID,
             &DOT,
             &KSM,
@@ -888,7 +896,9 @@ fn test_fee_when_exchange_on_one_source_of_many_should_pass() {
             ]
             .into(),
         );
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_C_ID,
             &GetBaseAssetId::get(),
             &DOT,
@@ -1566,7 +1576,7 @@ fn test_quote_should_return_rewards_for_multiple_sources() {
         MockLiquiditySource3::add_reward((balance!(301), DOT.into(), RewardReason::Unspecified));
 
         let amount: Balance = balance!(500);
-        let (_, rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo { rewards, .. } = LiquidityProxy::inner_quote(
             DEX_C_ID,
             &GetBaseAssetId::get(),
             &DOT,
@@ -2780,7 +2790,9 @@ fn test_quote_with_no_price_impact_with_desired_input() {
         ));
 
         // Buying KSM for VAL
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_D_ID,
             &VAL,
             &KSM,
@@ -2884,7 +2896,9 @@ fn test_quote_with_no_price_impact_with_desired_output() {
         ));
 
         // Buying KSM for VAL
-        let (quotes, _rewards, _) = LiquidityProxy::inner_quote(
+        let QuoteInfo {
+            outcome: quotes, ..
+        } = LiquidityProxy::inner_quote(
             DEX_D_ID,
             &VAL,
             &KSM,

--- a/run_script.sh
+++ b/run_script.sh
@@ -83,7 +83,7 @@ for name in alice bob charlie dave eve ferdie
 do
 	newport=`expr $port + 1`
 	rpcport=`expr $wsport + 10`
-	$binary key insert --chain $chain --suri "//${name^}" --scheme ecdsa --key-type ethb --base-path db$num
+	$binary key insert --chain $chain --suri "//${name}" --scheme ecdsa --key-type ethb --base-path db$num
 	mkdir -p "db$num/chains/sora-substrate-$chain/bridge"
 	cp misc/eth.json "db$num/chains/sora-substrate-$chain/bridge"
 	if [ "$num" == "0" ]; then

--- a/runtime/src/extensions.rs
+++ b/runtime/src/extensions.rs
@@ -118,6 +118,7 @@ impl crate::Call {
                     call,
                     Self::LiquidityProxy(liquidity_proxy::Call::swap { .. })
                         | Self::LiquidityProxy(liquidity_proxy::Call::swap_transfer { .. })
+                        | Self::LiquidityProxy(liquidity_proxy::Call::swap_transfer_batch { .. })
                 )
             }) {
                 return Err(TransactionValidityError::Invalid(InvalidTransaction::Call));


### PR DESCRIPTION
# Changes
- Added SwapBatchInfo struct, responsible for holding information about outcome asset, dex ID and related batch receivers
- Fixed run_script 
- Updated README.MD with instructions for macOS
- Added RuntimeDebug trait derivation for SwapBatchInfo and BatchReceiverInfo

Cherrypicked commits from #284