### PR TITLE
Add `amount_without_impact` to `liquidity_proxy.quote`

### DIFF
--- a/pallets/liquidity-proxy/runtime-api/src/lib.rs
+++ b/pallets/liquidity-proxy/runtime-api/src/lib.rs
@@ -65,6 +65,17 @@ pub struct SwapOutcomeInfo<Balance, AssetId: MaybeDisplay + MaybeFromStr> {
             with = "string_serialization"
         )
     )]
+    pub amount_without_impact: Balance,
+    #[cfg_attr(
+        feature = "std",
+        serde(
+            bound(
+                serialize = "Balance: std::fmt::Display",
+                deserialize = "Balance: std::str::FromStr"
+            ),
+            with = "string_serialization"
+        )
+    )]
     pub fee: Balance,
     pub rewards: Vec<RewardsInfo<Balance, AssetId>>,
     pub route: Vec<AssetId>,

--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -213,6 +213,7 @@ impl<LiquiditySourceIdType, AmountType> AggregatedSwapOutcome<LiquiditySourceIdT
 #[derive(Eq, PartialEq, Encode, Decode)]
 pub struct QuoteInfo<AssetId, LiquiditySource> {
     pub outcome: SwapOutcome<Balance>,
+    pub amount_without_impact: Option<Balance>,
     pub rewards: Rewards<AssetId>,
     pub liquidity_sources: Vec<LiquiditySource>,
     pub path: Vec<AssetId>,
@@ -693,8 +694,9 @@ impl<T: Config> Pallet<T> {
             };
             quote.map(|x| QuoteInfo {
                 outcome: x.0,
-                rewards: x.1,
-                liquidity_sources: x.2,
+                amount_without_impact: x.1,
+                rewards: x.2,
+                liquidity_sources: x.3,
                 path: atomic_path,
             })
         });
@@ -732,12 +734,14 @@ impl<T: Config> Pallet<T> {
     ) -> Result<
         (
             SwapOutcome<Balance>,
+            Option<Balance>,
             Rewards<T::AssetId>,
             Vec<LiquiditySourceIdOf<T>>,
         ),
         DispatchError,
     > {
         let mut current_amount = amount;
+        let init_outcome_without_impact = (!skip_info).then(|| balance!(0));
         fallible_iterator::convert(asset_pairs.map(|(from_asset_id, to_asset_id)| {
             let (quote, rewards, liquidity_sources) = Self::quote_single(
                 &dex_info.base_asset_id,
@@ -749,16 +753,33 @@ impl<T: Config> Pallet<T> {
                 deduce_fee,
             )?;
             current_amount = quote.amount;
-            Ok((quote, rewards, liquidity_sources))
+            Ok((quote, rewards, liquidity_sources, (from_asset_id, to_asset_id)))
         }))
         .fold(
             (
                 SwapOutcome::new(balance!(0), balance!(0)),
+                init_outcome_without_impact,
                 Rewards::new(),
                 Vec::new(),
             ),
-            |(mut outcome, mut rewards, mut liquidity_sources),
-             (quote, mut quote_rewards, quote_liquidity_sources)| {
+            |(
+                mut outcome,
+                mut outcome_without_impact,
+                mut rewards,
+                mut liquidity_sources,
+            ),
+             (quote, mut quote_rewards, quote_liquidity_sources, (from_asset, to_asset))| {
+                outcome_without_impact = outcome_without_impact.map(|without_impact| {
+                    Self::calculate_amount_without_impact(
+                        from_asset,
+                        to_asset,
+                        &quote.distribution,
+                        outcome.amount,
+                        without_impact,
+                        deduce_fee,
+                    )
+                })
+                    .transpose()?;
                 outcome.amount = quote.amount;
                 outcome.fee = outcome
                     .fee
@@ -766,9 +787,64 @@ impl<T: Config> Pallet<T> {
                     .ok_or(Error::<T>::CalculationError)?;
                 rewards.append(&mut quote_rewards);
                 merge_two_vectors_unique(&mut liquidity_sources, quote_liquidity_sources);
-                Ok((outcome, rewards, liquidity_sources))
+                Ok((
+                    outcome,
+                    outcome_without_impact,
+                    rewards,
+                    liquidity_sources,
+                ))
             },
         )
+    }
+
+    fn calculate_amount_without_impact(
+        input_asset_id: &T::AssetId,
+        output_asset_id: &T::AssetId,
+        distribution: &Vec<(
+            LiquiditySourceId<T::DEXId, LiquiditySourceType>,
+            QuoteAmount<Balance>,
+        )>,
+        outcome_amount: u128,
+        outcome_without_impact: u128,
+        deduce_fee: bool,
+    ) -> Result<Balance, DispatchError> {
+        let outcome_without_impact = if outcome_without_impact == 0 {
+            1
+        } else {
+            outcome_without_impact
+        };
+
+        // multiply all amounts in distribution to adjust prev quote without impact:
+        let distribution = distribution
+            .into_iter()
+            .filter(|(_, part_amount)| *part_amount > balance!(0))
+            .map(|(market, amount)| {
+                // Should not overflow unless the amounts are comparable to 10^38 .
+                // For reference, a trillion is 10^12.
+                let adjusted_amount = amount
+                    .amount()
+                    .checked_mul(outcome_without_impact)
+                    .ok_or(Error::<T>::FailedToCalculatePriceWithoutImpact)?
+                    .checked_div(outcome_amount)
+                    .ok_or(Error::<T>::FailedToCalculatePriceWithoutImpact)?;
+                Ok::<_, Error<T>>((market, amount.copy_direction(adjusted_amount)))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut accumulated_without_impact: Balance = 0;
+        for (src, part_amount) in distribution.into_iter() {
+            let part_outcome = T::LiquidityRegistry::quote_without_impact(
+                src,
+                input_asset_id,
+                output_asset_id,
+                part_amount,
+                deduce_fee,
+            )?;
+            accumulated_without_impact = accumulated_without_impact
+                .checked_add(part_outcome.amount)
+                .ok_or(Error::<T>::FailedToCalculatePriceWithoutImpact)?;
+        }
+        Ok(accumulated_without_impact)
     }
 
     /// Computes the optimal distribution across available liquidity sources to execute the requested trade

--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -817,10 +817,12 @@ impl<T: Config> Pallet<T> {
         // multiply all amounts in distribution to adjust prev quote without impact:
         let distribution = distribution
             .into_iter()
-            .filter(|(_, part_amount)| *part_amount > balance!(0))
+            .filter(|(_, part_amount)| part_amount.amount() > balance!(0))
             .map(|(market, amount)| {
                 // Should not overflow unless the amounts are comparable to 10^38 .
                 // For reference, a trillion is 10^12.
+                //
+                // same as mul by ratioToActual, just without floating point ops
                 let adjusted_amount = amount
                     .amount()
                     .checked_mul(outcome_without_impact)

--- a/pallets/liquidity-proxy/src/tests.rs
+++ b/pallets/liquidity-proxy/src/tests.rs
@@ -2753,6 +2753,22 @@ fn test_quote_with_no_price_impact_with_desired_input() {
                 ),
             ]
         ));
+        // without impact
+        let QuoteInfo {
+            amount_without_impact,
+            ..
+        } = LiquidityProxy::inner_quote(
+            DEX_D_ID,
+            &VAL,
+            &GetBaseAssetId::get(),
+            QuoteAmount::with_desired_input(amount_val_in),
+            filter.clone(),
+            false,
+            true,
+        )
+        .expect("Failed to get a quote");
+        assert_approx_eq!(quotes.amount, amount_without_impact.unwrap(), balance!(20));
+        assert!(amount_without_impact.unwrap() > quotes.amount);
 
         // Buying KSM for XOR
         let (quotes, _rewards, _) = LiquidityProxy::quote_single(
@@ -2789,10 +2805,28 @@ fn test_quote_with_no_price_impact_with_desired_input() {
                 ),
             ]
         ));
+        // without impact
+        let QuoteInfo {
+            amount_without_impact,
+            ..
+        } = LiquidityProxy::inner_quote(
+            DEX_D_ID,
+            &GetBaseAssetId::get(),
+            &KSM,
+            QuoteAmount::with_desired_input(amount_xor_intermediate),
+            filter.clone(),
+            false,
+            true,
+        )
+        .expect("Failed to get a quote");
+        assert_approx_eq!(quotes.amount, amount_without_impact.unwrap(), balance!(20));
+        assert!(amount_without_impact.unwrap() > quotes.amount);
 
         // Buying KSM for VAL
         let QuoteInfo {
-            outcome: quotes, ..
+            outcome: quotes,
+            amount_without_impact,
+            ..
         } = LiquidityProxy::inner_quote(
             DEX_D_ID,
             &VAL,
@@ -2804,6 +2838,8 @@ fn test_quote_with_no_price_impact_with_desired_input() {
         )
         .expect("Failed to get a quote");
         assert_approx_eq!(quotes.amount, amount_ksm_out, balance!(1));
+        assert_approx_eq!(amount_without_impact.unwrap(), amount_ksm_out, balance!(20));
+        assert!(amount_without_impact.unwrap() > quotes.amount);
     });
 }
 
@@ -2859,6 +2895,7 @@ fn test_quote_with_no_price_impact_with_desired_output() {
                 ),
             ]
         ));
+        // without impact
         let QuoteInfo {
             amount_without_impact,
             ..
@@ -2877,7 +2914,7 @@ fn test_quote_with_no_price_impact_with_desired_output() {
             amount_without_impact.unwrap(),
             balance!(5000)
         );
-        assert!(quotes.amount > amount_without_impact.unwrap());
+        assert!(amount_without_impact.unwrap() < quotes.amount);
 
         // Buying KSM for XOR
         let (quotes, _rewards, _) = LiquidityProxy::quote_single(
@@ -2914,6 +2951,7 @@ fn test_quote_with_no_price_impact_with_desired_output() {
                 ),
             ]
         ));
+        // without impact
         let QuoteInfo {
             amount_without_impact,
             ..

--- a/run_script.sh
+++ b/run_script.sh
@@ -22,6 +22,10 @@ else
 	unbuffer=""
 fi
 
+# MacOS default getopt doesn't support long args,
+# so installing gnu version should make it work.
+#
+# brew install gnu-getopt
 getopt_code=`$awk -f ./misc/getopt.awk <<EOF
 Usage: sh ./run_script.sh [OPTIONS]...
 Run frame node based local test net

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2393,7 +2393,7 @@ impl_runtime_apis! {
                 true,
             ).ok().map(|quote_info| liquidity_proxy_runtime_api::SwapOutcomeInfo::<Balance, AssetId> {
                 amount: quote_info.outcome.amount,
-                amount_without_impact: quote_info.amount_without_impact,
+                amount_without_impact: quote_info.amount_without_impact.unwrap_or(0),
                 fee: quote_info.outcome.fee,
                 rewards: quote_info.rewards.into_iter()
                                 .map(|(amount, currency, reason)| liquidity_proxy_runtime_api::RewardsInfo::<Balance, AssetId> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2393,6 +2393,7 @@ impl_runtime_apis! {
                 true,
             ).ok().map(|quote_info| liquidity_proxy_runtime_api::SwapOutcomeInfo::<Balance, AssetId> {
                 amount: quote_info.outcome.amount,
+                amount_without_impact: quote_info.amount_without_impact,
                 fee: quote_info.outcome.fee,
                 rewards: quote_info.rewards.into_iter()
                                 .map(|(amount, currency, reason)| liquidity_proxy_runtime_api::RewardsInfo::<Balance, AssetId> {


### PR DESCRIPTION
Calculate amount_without_impact and return with result of `quote` on liquidity proxy pallet.
[Frontend code](https://github.com/sora-xor/sora2-substrate-js-library/blob/d6421615199181aa9cb2c249bcd5e7db35e1d7b5/packages/liquidity-proxy/src/liquidityProxy.ts#L466) was used as a reference
Tests are returned back from [PR](https://github.com/soramitsu/sora2-substrate/pull/761/files) that removed this field