### PR TITLE
Fix/swap transfer batch slippage hotfix

### DIFF
--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -1788,6 +1788,11 @@ pub mod pallet {
                     if !unique_asset_ids.insert(asset_id.clone()) {
                         Err(Error::<T>::AggregationError)?
                     }
+
+                    if receivers.len() == 0 {
+                        Err(Error::<T>::InvalidReceiversInfo)?
+                    }
+
                     let out_amount = receivers.iter().map(|recv| recv.target_amount).sum();
                     let (executed_input_amount, remainder_per_receiver): (Balance, Balance) =
                         if asset_id != input_asset_id {
@@ -1970,5 +1975,7 @@ pub mod pallet {
         UnableToDisableLiquiditySource,
         /// Liquidity source is already disabled
         LiquiditySourceAlreadyDisabled,
+        // Information about swap batch receivers is invalid
+        InvalidReceiversInfo,
     }
 }


### PR DESCRIPTION
# Changes
- Fixed slippage check
- Added temporary solution for inner_exchange inaccurate exchange result

## Notes
inner_exchange executed output amount does not match desired output amount. It causes problems, if a caller does not hold any tokens requested in batches. To resolve this, I calculate a remainder (it's about 10^-15 tokens on average) and spread it between receivers.
I've used assets.totalBalance for remainder calculation, since inner_exchange's returned SwapOutcome holds info about executed input amount, not the output amount, as it stated in docs (see liquidityProxy.exchangeSequence code).

The problem originates from the inaccurate quote results, which are used for calculating input amount in WithDesiredOutput swap variant.