### PR TITLE
Replace mock.rs with chainspec in Assets' pallet tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,8 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "framenode-chain-spec",
+ "framenode-runtime",
  "hex-literal",
  "orml-currencies",
  "orml-tokens",

--- a/pallets/assets/Cargo.toml
+++ b/pallets/assets/Cargo.toml
@@ -39,6 +39,10 @@ sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkado
 common = { path = "../../common", features = ["test"] }
 permissions = { path = "../permissions" }
 
+framenode-chain-spec = { path = "../../node/chain_spec", features = ["test"] }
+framenode-runtime = { path = "../../runtime" }
+sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.25" }
+
 [features]
 default = ["std"]
 

--- a/pallets/assets/src/lib.rs
+++ b/pallets/assets/src/lib.rs
@@ -51,9 +51,6 @@ pub mod weights;
 mod benchmarking;
 
 #[cfg(test)]
-mod mock;
-
-#[cfg(test)]
 mod tests;
 
 use codec::{Decode, Encode};


### PR DESCRIPTION
# Changes
- mock.rs is removed
- mock is replaced with framenode chainspec in pallet's tests

# Note
Awaiting fixes:
- buy_back_and_burn_should_be_performed
- should_not_allow_burn_from_due_to_permissions