### PR TITLE
fix (bridge-docker): fix bugs in evm bridge docker:

### DIFF
--- a/bridge-docker/Dockerfile.sora
+++ b/bridge-docker/Dockerfile.sora
@@ -70,4 +70,10 @@ RUN cargo build --release --features private-net,wip,ready-to-test
 
 # runtime
 FROM debian:bullseye-slim
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    jq && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/framenode /app/target/release/relayer /usr/local/bin

--- a/bridge-docker/docker-compose.evm.yml
+++ b/bridge-docker/docker-compose.evm.yml
@@ -98,7 +98,7 @@ services:
     command: ["relayer",
         "--ethereum-url", "ws://bridge-geth:8545",
         "--substrate-url", "ws://bridge-sora-alice:9944",
-        "--substrate-key", "//Bob",
+        "--substrate-key", "//Relayer",
         "bridge", "relay", "ethereum",
         "--base-path", "/data"
       ]

--- a/bridge-scripts/run-ethereum-relay.sh
+++ b/bridge-scripts/run-ethereum-relay.sh
@@ -5,6 +5,6 @@ export RUST_LOG=info,relayer=debug
 cargo run --bin relayer --release -- \
     --ethereum-url ws://localhost:8546 \
     --substrate-url ws://localhost:9944 \
-    --substrate-key //Bob \
+    --substrate-key //Relayer \
     bridge relay ethereum \
     --base-path /tmp/relayer


### PR DESCRIPTION
- obsolete account Bob changed to Relayer
- added missing `jq` dependency to Sora Dockerfile