### PR TITLE
Exception for creation of pools involving XSTUSD

### DIFF
--- a/pallets/pool-xyk/src/lib.rs
+++ b/pallets/pool-xyk/src/lib.rs
@@ -808,7 +808,11 @@ pub mod pallet {
                     Error::<T>::UnableToCreatePoolWithIndivisibleAssets
                 );
 
-                let synthetic_assets = T::XSTMarketInfo::enabled_target_assets();
+                let mut synthetic_assets = T::XSTMarketInfo::enabled_target_assets();
+                // in case if XSTUSD is the base asset, we might want to create a pool anyways
+                // TODO: #392 use DexInfoProvider instead of dex-manager pallet
+                synthetic_assets
+                    .remove(&dex_manager::Pallet::<T>::get_dex_info(&dex_id)?.base_asset_id);
                 ensure!(
                     !synthetic_assets.contains(&asset_a) && !synthetic_assets.contains(&asset_b),
                     Error::<T>::UnableToCreatePoolWithSyntheticAssets

--- a/pallets/pool-xyk/src/tests.rs
+++ b/pallets/pool-xyk/src/tests.rs
@@ -2307,14 +2307,11 @@ fn initialize_pool_with_synthetics() {
             ),
             crate::Error::<Runtime>::UnableToCreatePoolWithSyntheticAssets
         );
-        assert_noop!(
-            PoolXYK::initialize_pool(
-                RuntimeOrigin::signed(ALICE()),
-                DEX_C_ID,
-                Mango.into(),
-                GoldenTicket.into()
-            ),
-            crate::Error::<Runtime>::UnableToCreatePoolWithSyntheticAssets
-        );
+        assert_ok!(PoolXYK::initialize_pool(
+            RuntimeOrigin::signed(ALICE()),
+            DEX_C_ID,
+            Mango.into(),
+            GoldenTicket.into()
+        ));
     });
 }


### PR DESCRIPTION
# Changes
- If the XSTUSD is the base asset in the DEX, then the pool could be initialized

## Notes
LiquidityProxy with its current functionality allows swapping XSTUSD to some other assets directly, since it could be considered as base asset, so there was no need to modify it. 