### PR TITLE
Allow only Polkaswap DEX for OrderBook creation

### DIFF
--- a/common/src/primitives.rs
+++ b/common/src/primitives.rs
@@ -1083,7 +1083,7 @@ pub enum PriceVariant {
 }
 
 impl PriceVariant {
-    pub fn switch(&self) -> Self {
+    pub fn switched(&self) -> Self {
         match self {
             PriceVariant::Buy => PriceVariant::Sell,
             PriceVariant::Sell => PriceVariant::Buy,

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -130,6 +130,7 @@ pub mod pallet {
         type MaxSidePriceCount: Get<u32>;
         type MaxExpiringOrdersPerBlock: Get<u32>;
         type MaxExpirationWeightPerBlock: Get<Weight>;
+        type AllowedDEXIds: Get<&'static [Self::DEXId]>;
         type EnsureTradingPairExists: EnsureTradingPairExists<
             Self::DEXId,
             Self::AssetId,

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -130,7 +130,6 @@ pub mod pallet {
         type MaxSidePriceCount: Get<u32>;
         type MaxExpiringOrdersPerBlock: Get<u32>;
         type MaxExpirationWeightPerBlock: Get<Weight>;
-        type AllowedDEXIds: Get<&'static [Self::DEXId]>;
         type EnsureTradingPairExists: EnsureTradingPairExists<
             Self::DEXId,
             Self::AssetId,
@@ -415,10 +414,9 @@ pub mod pallet {
                 order_book_id.base != order_book_id.quote,
                 Error::<T>::ForbiddenToCreateOrderBookWithSameAssets
             );
+            // https://github.com/sora-xor/sora2-network/issues/536
             ensure!(
-                T::AllowedDEXIds::get()
-                    .iter()
-                    .any(|allowed| allowed == &dex_id),
+                dex_id == common::DEXId::Polkaswap.into(),
                 Error::<T>::NotAllowedDEXId
             );
             let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -341,6 +341,8 @@ pub mod pallet {
         ForbiddenToCreateOrderBookWithSameAssets,
         /// The asset is not allowed to be base. Only dex base asset can be a quote asset for order book
         NotAllowedBaseAsset,
+        /// Orderbooks cannot be created with given dex id.
+        NotAllowedDEXId,
         /// User cannot create an order book with NFT if they don't have NFT
         UserHasNoNft,
         /// Lifespan exceeds defined limits
@@ -412,6 +414,12 @@ pub mod pallet {
             ensure!(
                 order_book_id.base != order_book_id.quote,
                 Error::<T>::ForbiddenToCreateOrderBookWithSameAssets
+            );
+            ensure!(
+                T::AllowedDEXIds::get()
+                    .iter()
+                    .any(|allowed| allowed == &dex_id),
+                Error::<T>::NotAllowedDEXId
             );
             let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
             // the base asset of DEX must be a quote asset of order book

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -416,7 +416,6 @@ pub mod pallet {
                 order_book_id.base != order_book_id.quote,
                 Error::<T>::ForbiddenToCreateOrderBookWithSameAssets
             );
-            // https://github.com/sora-xor/sora2-network/issues/536
             ensure!(
                 dex_id == common::DEXId::Polkaswap.into(),
                 Error::<T>::NotAllowedDEXId

--- a/pallets/order-book/src/order_book.rs
+++ b/pallets/order-book/src/order_book.rs
@@ -314,7 +314,7 @@ impl<T: crate::Config + Sized> OrderBook<T> {
         let mut makers_output = BTreeMap::new();
 
         for (price, _) in market_data {
-            let Some(price_level) = data.get_limit_orders_by_price(&self.order_book_id, side.switch(), price) else {
+            let Some(price_level) = data.get_limit_orders_by_price(&self.order_book_id, side.switched(), price) else {
                 return Err(Error::<T>::NotEnoughLiquidity.into());
             };
 

--- a/pallets/order-book/src/tests/order_book.rs
+++ b/pallets/order-book/src/tests/order_book.rs
@@ -574,12 +574,12 @@ fn should_not_place_limit_order_that_doesnt_meet_restrictions_for_orders_in_pric
             buy_order.id += 1;
             buy_order.owner = account.clone();
             // should ideally be set through `LimitOrder::new`
-            // but let's do it in a hacky way for simplicity
+            // but we do it in a hacky way for simplicity
             buy_order.expires_at += 1;
             sell_order.id += 1;
             sell_order.owner = account;
             // should ideally be set through `LimitOrder::new`
-            // but let's do it in a hacky way for simplicity
+            // but we do it in a hacky way for simplicity
             sell_order.expires_at += 1;
 
             assert_ok!(
@@ -655,10 +655,16 @@ fn should_not_place_limit_order_that_doesnt_meet_restrictions_for_side() {
             buy_order.id += 1;
             buy_order.owner = account.clone();
             buy_order.price -= order_book.tick_size;
+            // should ideally be set through `LimitOrder::new`
+            // but we do it in a hacky way for simplicity
+            buy_order.expires_at += 1;
 
             sell_order.id += 1;
             sell_order.owner = account;
             sell_order.price += order_book.tick_size;
+            // should ideally be set through `LimitOrder::new`
+            // but we do it in a hacky way for simplicity
+            sell_order.expires_at += 1;
 
             assert_ok!(
                 order_book.place_limit_order::<OrderBookPallet, OrderBookPallet>(

--- a/pallets/price-tools/src/lib.rs
+++ b/pallets/price-tools/src/lib.rs
@@ -214,7 +214,7 @@ impl<T: Config> Pallet<T> {
             }
             (input, xor) if xor == &XOR.into() => {
                 // Buy price should always be greater or equal to sell price, so we need to invert price_variant here
-                Self::get_asset_average_price(input, price_variant.switch()).and_then(
+                Self::get_asset_average_price(input, price_variant.switched()).and_then(
                     |average_price| {
                         (fixed_wrapper!(1) / average_price)
                             .try_into_balance()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2016,6 +2016,8 @@ impl hermes_governance_platform::Config for Runtime {
 parameter_types! {
     // small value for test environment in order to check postponing expirations
     pub ExpirationsSchedulerMaxWeight: Weight = Perbill::from_percent(15) * BlockWeights::get().max_block; // TODO: order-book clarify
+    // `.into()` is not `const`, thus using `as u32`
+    pub const OrderbookAllowedDEXIds: &'static [DEXId] = &[common::DEXId::Polkaswap as u32];
 }
 
 #[cfg(feature = "wip")] // order-book
@@ -2030,6 +2032,7 @@ impl order_book::Config for Runtime {
     type MaxLimitOrdersForPrice = ConstU32<10000>; // TODO: order-book clarify
     type MaxSidePriceCount = ConstU32<100000>; // TODO: order-book clarify
     type MaxExpiringOrdersPerBlock = ConstU32<10000>; // TODO: order-book clarify
+    type AllowedDEXIds = OrderbookAllowedDEXIds;
     type MaxExpirationWeightPerBlock = ExpirationsSchedulerMaxWeight;
     type EnsureTradingPairExists = TradingPair;
     type TradingPairSourceManager = TradingPair;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2016,8 +2016,6 @@ impl hermes_governance_platform::Config for Runtime {
 parameter_types! {
     // small value for test environment in order to check postponing expirations
     pub ExpirationsSchedulerMaxWeight: Weight = Perbill::from_percent(15) * BlockWeights::get().max_block; // TODO: order-book clarify
-    // `.into()` is not `const`, thus using `as u32`
-    pub const OrderbookAllowedDEXIds: &'static [DEXId] = &[common::DEXId::Polkaswap as u32];
 }
 
 #[cfg(feature = "wip")] // order-book
@@ -2032,7 +2030,6 @@ impl order_book::Config for Runtime {
     type MaxLimitOrdersForPrice = ConstU32<10000>; // TODO: order-book clarify
     type MaxSidePriceCount = ConstU32<100000>; // TODO: order-book clarify
     type MaxExpiringOrdersPerBlock = ConstU32<10000>; // TODO: order-book clarify
-    type AllowedDEXIds = OrderbookAllowedDEXIds;
     type MaxExpirationWeightPerBlock = ExpirationsSchedulerMaxWeight;
     type EnsureTradingPairExists = TradingPair;
     type TradingPairSourceManager = TradingPair;


### PR DESCRIPTION
Check the dex_id + minor fixes:
- rename `switch` to `switched` to more accurately represent meaning of the function
- fix heavy tests to surpass scheduler limits