### PR TITLE
Use InfoProvider traits instead of pallets

### DIFF
--- a/pallets/ceres-governance-platform/src/mock.rs
+++ b/pallets/ceres-governance-platform/src/mock.rs
@@ -147,6 +147,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -173,7 +174,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {
@@ -208,6 +208,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/ceres-governance-platform/src/mock.rs
+++ b/pallets/ceres-governance-platform/src/mock.rs
@@ -173,6 +173,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/ceres-launchpad/src/mock.rs
+++ b/pallets/ceres-launchpad/src/mock.rs
@@ -186,6 +186,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl multicollateral_bonding_curve_pool::Config for Runtime {

--- a/pallets/ceres-launchpad/src/mock.rs
+++ b/pallets/ceres-launchpad/src/mock.rs
@@ -160,6 +160,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -186,7 +187,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl multicollateral_bonding_curve_pool::Config for Runtime {
@@ -252,6 +252,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/ceres-liquidity-locker/benchmarking/src/mock.rs
+++ b/pallets/ceres-liquidity-locker/benchmarking/src/mock.rs
@@ -170,6 +170,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -185,7 +186,6 @@ impl dex_api::Config for Runtime {
     type MulticollateralBondingCurvePool = ();
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
@@ -223,7 +223,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pswap_distribution::Config for Runtime {
@@ -242,6 +241,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/ceres-liquidity-locker/benchmarking/src/mock.rs
+++ b/pallets/ceres-liquidity-locker/benchmarking/src/mock.rs
@@ -185,6 +185,7 @@ impl dex_api::Config for Runtime {
     type MulticollateralBondingCurvePool = ();
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();

--- a/pallets/ceres-liquidity-locker/benchmarking/src/mock.rs
+++ b/pallets/ceres-liquidity-locker/benchmarking/src/mock.rs
@@ -223,6 +223,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pswap_distribution::Config for Runtime {

--- a/pallets/ceres-liquidity-locker/src/mock.rs
+++ b/pallets/ceres-liquidity-locker/src/mock.rs
@@ -228,6 +228,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);

--- a/pallets/ceres-liquidity-locker/src/mock.rs
+++ b/pallets/ceres-liquidity-locker/src/mock.rs
@@ -121,6 +121,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -228,7 +229,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);
@@ -246,6 +246,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl ceres_liquidity_locker::Config for Runtime {

--- a/pallets/ceres-token-locker/src/mock.rs
+++ b/pallets/ceres-token-locker/src/mock.rs
@@ -147,6 +147,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -173,7 +174,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -191,6 +191,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/ceres-token-locker/src/mock.rs
+++ b/pallets/ceres-token-locker/src/mock.rs
@@ -173,6 +173,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;

--- a/pallets/demeter-farming-platform/benchmarking/src/mock.rs
+++ b/pallets/demeter-farming-platform/benchmarking/src/mock.rs
@@ -181,6 +181,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 parameter_types! {
     pub const CeresAssetId: AssetId = CERES_ASSET_ID;

--- a/pallets/demeter-farming-platform/benchmarking/src/mock.rs
+++ b/pallets/demeter-farming-platform/benchmarking/src/mock.rs
@@ -162,6 +162,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -181,7 +182,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 parameter_types! {
     pub const CeresAssetId: AssetId = CERES_ASSET_ID;
@@ -240,6 +240,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/demeter-farming-platform/src/mock.rs
+++ b/pallets/demeter-farming-platform/src/mock.rs
@@ -178,6 +178,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 parameter_types! {
     pub const CeresAssetId: AssetId = CERES_ASSET_ID;

--- a/pallets/demeter-farming-platform/src/mock.rs
+++ b/pallets/demeter-farming-platform/src/mock.rs
@@ -159,6 +159,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -178,7 +179,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 parameter_types! {
     pub const CeresAssetId: AssetId = CERES_ASSET_ID;
@@ -237,6 +237,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/dex-api/src/lib.rs
+++ b/pallets/dex-api/src/lib.rs
@@ -45,8 +45,6 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-type DEXInfo<T> = common::prelude::DEXInfo<<T as assets::Config>::AssetId>;
-
 impl<T: Config>
     LiquiditySource<
         LiquiditySourceId<T::DEXId, LiquiditySourceType>,
@@ -388,7 +386,6 @@ pub mod pallet {
             Balance,
             DispatchError,
         >;
-        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self>>;
 
         #[cfg(feature = "ready-to-test")] // order-book
         type OrderBook: LiquiditySource<

--- a/pallets/dex-api/src/lib.rs
+++ b/pallets/dex-api/src/lib.rs
@@ -45,7 +45,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-type DEXManager<T> = dex_manager::Pallet<T>;
+type DEXInfo<T> = common::prelude::DEXInfo<<T as assets::Config>::AssetId>;
 
 impl<T: Config>
     LiquiditySource<
@@ -304,7 +304,7 @@ impl<T: Config>
         filter: LiquiditySourceFilter<T::DEXId, LiquiditySourceType>,
     ) -> Result<Vec<LiquiditySourceId<T::DEXId, LiquiditySourceType>>, DispatchError> {
         let supported_types = Self::get_supported_types();
-        DEXManager::<T>::ensure_dex_exists(&filter.dex_id)?;
+        T::DexInfoProvider::ensure_dex_exists(&filter.dex_id)?;
         Ok(supported_types
             .iter()
             .filter_map(|source_type| {
@@ -335,10 +335,9 @@ pub mod pallet {
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
 
-    // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     #[pallet::config]
     pub trait Config:
-        frame_system::Config + common::Config + dex_manager::Config + trading_pair::Config
+        frame_system::Config + common::Config + trading_pair::Config + assets::Config
     {
         type MockLiquiditySource: LiquiditySource<
             Self::DEXId,
@@ -388,6 +387,10 @@ pub mod pallet {
             Self::AssetId,
             Balance,
             DispatchError,
+        >;
+        type DexInfoProvider: DexInfoProvider<
+            Self::DEXId,
+            DEXInfo<Self>,
         >;
 
         #[cfg(feature = "ready-to-test")] // order-book

--- a/pallets/dex-api/src/lib.rs
+++ b/pallets/dex-api/src/lib.rs
@@ -388,10 +388,7 @@ pub mod pallet {
             Balance,
             DispatchError,
         >;
-        type DexInfoProvider: DexInfoProvider<
-            Self::DEXId,
-            DEXInfo<Self>,
-        >;
+        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self>>;
 
         #[cfg(feature = "ready-to-test")] // order-book
         type OrderBook: LiquiditySource<

--- a/pallets/dex-api/src/mock.rs
+++ b/pallets/dex-api/src/mock.rs
@@ -239,24 +239,28 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance2> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance3> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance4> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/dex-api/src/mock.rs
+++ b/pallets/dex-api/src/mock.rs
@@ -159,6 +159,7 @@ impl Config for Runtime {
     type MulticollateralBondingCurvePool = ();
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
+    type DexInfoProvider = DexManager;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();

--- a/pallets/dex-api/src/mock.rs
+++ b/pallets/dex-api/src/mock.rs
@@ -159,7 +159,6 @@ impl Config for Runtime {
     type MulticollateralBondingCurvePool = ();
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
-    type DexInfoProvider = DexManager;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
@@ -277,6 +276,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -303,7 +303,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);
@@ -321,6 +320,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/dex-api/src/mock.rs
+++ b/pallets/dex-api/src/mock.rs
@@ -303,6 +303,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);

--- a/pallets/farming/src/mock.rs
+++ b/pallets/farming/src/mock.rs
@@ -189,6 +189,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -292,7 +293,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);
@@ -310,6 +310,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl multicollateral_bonding_curve_pool::Config for Runtime {

--- a/pallets/farming/src/mock.rs
+++ b/pallets/farming/src/mock.rs
@@ -292,6 +292,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);

--- a/pallets/hermes-governance-platform/src/mock.rs
+++ b/pallets/hermes-governance-platform/src/mock.rs
@@ -199,6 +199,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/hermes-governance-platform/src/mock.rs
+++ b/pallets/hermes-governance-platform/src/mock.rs
@@ -167,6 +167,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -199,7 +200,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;
@@ -233,6 +233,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/liquidity-proxy/benchmarking/src/lib.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/lib.rs
@@ -115,7 +115,7 @@ benchmarks! {
     }
 
     new_trivial {
-        let dex_info = <T as liquidity_proxy::Config>::DexInfoProvider::get_dex_info(&DEX.into())?;
+        let dex_info = <T as trading_pair::Config>::DexInfoProvider::get_dex_info(&DEX.into())?;
         let from_asset: T::AssetId = XSTUSD.into();
         let to_asset: T::AssetId = VAL.into();
     }: {

--- a/pallets/liquidity-proxy/benchmarking/src/lib.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/lib.rs
@@ -115,7 +115,7 @@ benchmarks! {
     }
 
     new_trivial {
-        let dex_info = T::DexInfoProvider::get_dex_info(&DEX.into())?;
+        let dex_info = <T as liquidity_proxy::Config>::DexInfoProvider::get_dex_info(&DEX.into())?;
         let from_asset: T::AssetId = XSTUSD.into();
         let to_asset: T::AssetId = VAL.into();
     }: {

--- a/pallets/liquidity-proxy/benchmarking/src/lib.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/lib.rs
@@ -115,8 +115,7 @@ benchmarks! {
     }
 
     new_trivial {
-        // TODO: #392 use DexInfoProvider instead of dex-manager pallet
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&DEX.into())?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&DEX.into())?;
         let from_asset: T::AssetId = XSTUSD.into();
         let to_asset: T::AssetId = VAL.into();
     }: {

--- a/pallets/liquidity-proxy/benchmarking/src/mock.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/mock.rs
@@ -171,7 +171,6 @@ impl liquidity_proxy::Config for Runtime {
     type VestedRewardsPallet = vested_rewards::Pallet<Runtime>;
     type GetADARAccountId = GetADARAccountId;
     type ADARCommissionRatioUpdateOrigin = EnsureRoot<AccountId>;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl tokens::Config for Runtime {
@@ -292,7 +291,6 @@ impl dex_api::Config for Runtime {
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
     type MulticollateralBondingCurvePool = multicollateral_bonding_curve_pool::Pallet<Runtime>;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
@@ -301,6 +299,7 @@ impl dex_api::Config for Runtime {
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -327,7 +326,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl vested_rewards::Config for Runtime {
     const BLOCKS_PER_DAY: BlockNumberFor<Self> = 14400;
@@ -517,6 +515,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl price_tools::Config for Runtime {

--- a/pallets/liquidity-proxy/benchmarking/src/mock.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/mock.rs
@@ -247,24 +247,28 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance2> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance3> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance4> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/liquidity-proxy/benchmarking/src/mock.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/mock.rs
@@ -171,6 +171,7 @@ impl liquidity_proxy::Config for Runtime {
     type VestedRewardsPallet = vested_rewards::Pallet<Runtime>;
     type GetADARAccountId = GetADARAccountId;
     type ADARCommissionRatioUpdateOrigin = EnsureRoot<AccountId>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl tokens::Config for Runtime {
@@ -288,7 +289,7 @@ impl dex_api::Config for Runtime {
     type XSTPool = ();
     type MulticollateralBondingCurvePool = multicollateral_bonding_curve_pool::Pallet<Runtime>;
     type DexInfoProvider = dex_manager::Pallet<Runtime>;
-    
+
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
 }

--- a/pallets/liquidity-proxy/benchmarking/src/mock.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/mock.rs
@@ -327,6 +327,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl vested_rewards::Config for Runtime {
     const BLOCKS_PER_DAY: BlockNumberFor<Self> = 14400;

--- a/pallets/liquidity-proxy/benchmarking/src/mock.rs
+++ b/pallets/liquidity-proxy/benchmarking/src/mock.rs
@@ -287,7 +287,8 @@ impl dex_api::Config for Runtime {
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
     type MulticollateralBondingCurvePool = multicollateral_bonding_curve_pool::Pallet<Runtime>;
-
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
+    
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
 }

--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -2169,7 +2169,6 @@ pub mod pallet {
         type VestedRewardsPallet: VestedRewardsPallet<Self::AccountId, Self::AssetId>;
         type GetADARAccountId: Get<Self::AccountId>;
         type ADARCommissionRatioUpdateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
         /// Weight information for the extrinsics in this Pallet.
         type WeightInfo: WeightInfo;
     }

--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -62,7 +62,6 @@ use sp_std::prelude::*;
 use sp_std::{cmp::Ord, cmp::Ordering, vec};
 
 type LiquiditySourceIdOf<T> = LiquiditySourceId<<T as common::Config>::DEXId, LiquiditySourceType>;
-
 type Rewards<AssetId> = Vec<(Balance, AssetId, RewardReason)>;
 
 pub mod weights;
@@ -374,7 +373,7 @@ impl<T: Config> Pallet<T> {
         );
 
         common::with_transaction(|| {
-            let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+            let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
             let maybe_path =
                 ExchangePath::<T>::new_trivial(&dex_info, *input_asset_id, *output_asset_id);
             let total_weight = <T as Config>::WeightInfo::new_trivial();
@@ -666,7 +665,7 @@ impl<T: Config> Pallet<T> {
             input_asset_id != output_asset_id,
             Error::<T>::UnavailableExchangePath
         );
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let maybe_path =
             ExchangePath::<T>::new_trivial(&dex_info, *input_asset_id, *output_asset_id);
         maybe_path.map_or_else(
@@ -1081,7 +1080,7 @@ impl<T: Config> Pallet<T> {
         input_asset_id: T::AssetId,
         output_asset_id: T::AssetId,
     ) -> Result<bool, DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let maybe_path = ExchangePath::<T>::new_trivial(&dex_info, input_asset_id, output_asset_id);
         maybe_path.map_or(Ok(false), |paths| {
             let paths_flag = paths
@@ -1198,7 +1197,7 @@ impl<T: Config> Pallet<T> {
         swap_variant: SwapVariant,
     ) -> Weight {
         // Get DEX info or return weight that will be rejected
-        let Ok(dex_info) = dex_manager::Pallet::<T>::get_dex_info(dex_id) else {
+        let Ok(dex_info) = T::DexInfoProvider::get_dex_info(dex_id) else {
             return REJECTION_WEIGHT;
         };
 
@@ -1328,7 +1327,7 @@ impl<T: Config> Pallet<T> {
         input_asset_id: T::AssetId,
         output_asset_id: T::AssetId,
     ) -> Result<Vec<LiquiditySourceType>, DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let maybe_path = ExchangePath::<T>::new_trivial(&dex_info, input_asset_id, output_asset_id);
         maybe_path.map_or_else(
             || Err(Error::<T>::UnavailableExchangePath.into()),
@@ -2147,7 +2146,6 @@ pub mod pallet {
     use frame_support::{traits::StorageVersion, transactional};
     use frame_system::pallet_prelude::*;
 
-    // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     // TODO: #395 use AssetInfoProvider instead of assets pallet
     // TODO: #441 use TradingPairSourceManager instead of trading-pair pallet
     #[pallet::config]
@@ -2171,6 +2169,7 @@ pub mod pallet {
         type VestedRewardsPallet: VestedRewardsPallet<Self::AccountId, Self::AssetId>;
         type GetADARAccountId: Get<Self::AccountId>;
         type ADARCommissionRatioUpdateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
         /// Weight information for the extrinsics in this Pallet.
         type WeightInfo: WeightInfo;
     }

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -201,7 +201,6 @@ impl Config for Runtime {
     type VestedRewardsPallet = vested_rewards::Pallet<Runtime>;
     type GetADARAccountId = GetADARAccountId;
     type ADARCommissionRatioUpdateOrigin = EnsureRoot<AccountId>;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl tokens::Config for Runtime {
@@ -326,7 +325,6 @@ impl dex_api::Config for Runtime {
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type MulticollateralBondingCurvePool = MockMCBCPool;
     type XSTPool = MockXSTPool;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = (); // todo
@@ -335,6 +333,7 @@ impl dex_api::Config for Runtime {
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -354,6 +353,7 @@ impl pswap_distribution::Config for Runtime {
     type WeightInfo = ();
     type GetParliamentAccountId = GetParliamentAccountId;
     type BuyBackHandler = LiquidityProxyBuyBackHandler<Runtime, GetBuyBackDexId>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl demeter_farming_platform::Config for Runtime {
@@ -379,7 +379,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -277,24 +277,28 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = GetFee0;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance2> for Runtime {
     type GetFee = GetFee10;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance3> for Runtime {
     type GetFee = GetFee20;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance4> for Runtime {
     type GetFee = GetFee30;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -379,6 +379,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -201,6 +201,7 @@ impl Config for Runtime {
     type VestedRewardsPallet = vested_rewards::Pallet<Runtime>;
     type GetADARAccountId = GetADARAccountId;
     type ADARCommissionRatioUpdateOrigin = EnsureRoot<AccountId>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl tokens::Config for Runtime {

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -321,6 +321,7 @@ impl dex_api::Config for Runtime {
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type MulticollateralBondingCurvePool = MockMCBCPool;
     type XSTPool = MockXSTPool;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = (); // todo

--- a/pallets/mock-liquidity-source/src/lib.rs
+++ b/pallets/mock-liquidity-source/src/lib.rs
@@ -268,7 +268,7 @@ impl<T: Config<I>, I: 'static>
         input_asset_id: &T::AssetId,
         output_asset_id: &T::AssetId,
     ) -> bool {
-        if let Ok(dex_info) = dex_manager::Pallet::<T>::get_dex_info(dex_id) {
+        if let Ok(dex_info) = T::DexInfoProvider::get_dex_info(dex_id) {
             if input_asset_id == &dex_info.base_asset_id {
                 <Reserves<T, I>>::contains_key(dex_id, output_asset_id)
             } else if output_asset_id == &dex_info.base_asset_id {
@@ -289,7 +289,7 @@ impl<T: Config<I>, I: 'static>
         amount: QuoteAmount<Balance>,
         deduce_fee: bool,
     ) -> Result<(SwapOutcome<Balance>, Weight), DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(dex_id)?;
         let amount = amount
             .try_into()
             .map_err(|_| Error::<T, I>::CalculationError)?;
@@ -443,7 +443,7 @@ impl<T: Config<I>, I: 'static>
         amount: QuoteAmount<Balance>,
         _deduce_fee: bool,
     ) -> Result<SwapOutcome<Balance>, DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(dex_id)?;
         if input_asset_id == &dex_info.base_asset_id {
             let (base_reserve, target_reserve) = <Reserves<T, I>>::get(dex_id, output_asset_id);
             let base_price_wrt_target = FixedWrapper::from(target_reserve) / base_reserve;
@@ -521,7 +521,7 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use common::{EnsureDEXManager, EnsureTradingPairExists, ManagementMode};
+    use common::{DEXInfo, EnsureDEXManager, EnsureTradingPairExists, ManagementMode};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
@@ -529,11 +529,7 @@ pub mod pallet {
     // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     #[pallet::config]
     pub trait Config<I: 'static = ()>:
-        frame_system::Config
-        + common::Config
-        + assets::Config
-        + technical::Config
-        + dex_manager::Config
+        frame_system::Config + common::Config + assets::Config + technical::Config
     {
         type GetFee: Get<Fixed>;
         type EnsureDEXManager: EnsureDEXManager<Self::DEXId, Self::AccountId, DispatchError>;
@@ -542,6 +538,7 @@ pub mod pallet {
             Self::AssetId,
             DispatchError,
         >;
+        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
     }
 
     /// The current storage version.

--- a/pallets/mock-liquidity-source/src/lib.rs
+++ b/pallets/mock-liquidity-source/src/lib.rs
@@ -526,7 +526,6 @@ pub mod pallet {
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
 
-    // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     #[pallet::config]
     pub trait Config<I: 'static = ()>:
         frame_system::Config + common::Config + assets::Config + technical::Config

--- a/pallets/mock-liquidity-source/src/mock.rs
+++ b/pallets/mock-liquidity-source/src/mock.rs
@@ -124,12 +124,14 @@ impl Config<crate::Instance1> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl Config<crate::Instance2> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl technical::Config for Runtime {

--- a/pallets/mock-liquidity-source/src/mock.rs
+++ b/pallets/mock-liquidity-source/src/mock.rs
@@ -218,6 +218,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 

--- a/pallets/multicollateral-bonding-curve-pool/src/mock.rs
+++ b/pallets/multicollateral-bonding-curve-pool/src/mock.rs
@@ -386,6 +386,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/multicollateral-bonding-curve-pool/src/mock.rs
+++ b/pallets/multicollateral-bonding-curve-pool/src/mock.rs
@@ -185,6 +185,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -355,6 +356,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl price_tools::Config for Runtime {
@@ -386,7 +388,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/multicollateral-bonding-curve-pool/src/mock.rs
+++ b/pallets/multicollateral-bonding-curve-pool/src/mock.rs
@@ -192,6 +192,7 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = ();
     type EnsureDEXManager = ();
     type EnsureTradingPairExists = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl Config for Runtime {

--- a/pallets/pool-xyk/benchmarking/src/mock.rs
+++ b/pallets/pool-xyk/benchmarking/src/mock.rs
@@ -199,6 +199,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -214,7 +215,6 @@ impl dex_api::Config for Runtime {
     type MulticollateralBondingCurvePool = ();
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
@@ -252,7 +252,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);
@@ -270,6 +269,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/pool-xyk/benchmarking/src/mock.rs
+++ b/pallets/pool-xyk/benchmarking/src/mock.rs
@@ -252,6 +252,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pswap_distribution::Config for Runtime {
     const PSWAP_BURN_PERCENT: Percent = Percent::from_percent(3);

--- a/pallets/pool-xyk/benchmarking/src/mock.rs
+++ b/pallets/pool-xyk/benchmarking/src/mock.rs
@@ -214,6 +214,7 @@ impl dex_api::Config for Runtime {
     type MulticollateralBondingCurvePool = ();
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();

--- a/pallets/pool-xyk/src/aliases.rs
+++ b/pallets/pool-xyk/src/aliases.rs
@@ -50,5 +50,3 @@ pub type WithdrawLiquidityActionOf<T> =
 
 pub type DepositLiquidityActionOf<T> =
     DepositLiquidityAction<AssetIdOf<T>, AccountIdOf<T>, TechAccountIdOf<T>>;
-
-pub type DEXManager<T> = dex_manager::Pallet<T>;

--- a/pallets/pool-xyk/src/lib.rs
+++ b/pallets/pool-xyk/src/lib.rs
@@ -166,7 +166,7 @@ impl<T: Config> Pallet<T> {
         reserves_account_id: &T::AccountId,
         fees_account_id: &T::AccountId,
     ) -> DispatchResult {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(dex_id)?;
         let (sorted_asset_a, sorted_asset_b) = if dex_info.base_asset_id == *asset_a {
             (asset_a, asset_b)
         } else if dex_info.base_asset_id == *asset_b {
@@ -267,7 +267,7 @@ impl<T: Config> Pallet<T> {
         input_a_min: Balance,
         input_b_min: Balance,
     ) -> DispatchResult {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let (_, tech_acc_id) = Pallet::<T>::tech_account_from_dex_and_asset_pair(
             dex_id,
             input_asset_a,
@@ -305,7 +305,7 @@ impl<T: Config> Pallet<T> {
         output_a_min: Balance,
         output_b_min: Balance,
     ) -> DispatchResult {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let (_, tech_acc_id) = Pallet::<T>::tech_account_from_dex_and_asset_pair(
             dex_id,
             output_asset_a,
@@ -356,7 +356,7 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
         input_asset_id: &T::AssetId,
         output_asset_id: &T::AssetId,
     ) -> bool {
-        if let Ok(dex_info) = dex_manager::Pallet::<T>::get_dex_info(dex_id) {
+        if let Ok(dex_info) = T::DexInfoProvider::get_dex_info(dex_id) {
             let target_asset_id = if *input_asset_id == dex_info.base_asset_id {
                 output_asset_id
             } else if *output_asset_id == dex_info.base_asset_id {
@@ -378,7 +378,7 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
         amount: QuoteAmount<Balance>,
         deduce_fee: bool,
     ) -> Result<(SwapOutcome<Balance>, Weight), DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(dex_id)?;
         // Get pool account.
         let (_, tech_acc_id) = Pallet::<T>::tech_account_from_dex_and_asset_pair(
             *dex_id,
@@ -440,7 +440,7 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
         output_asset_id: &T::AssetId,
         swap_amount: SwapAmount<Balance>,
     ) -> Result<(SwapOutcome<Balance>, Weight), DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let (_, tech_acc_id) = Pallet::<T>::tech_account_from_dex_and_asset_pair(
             *dex_id,
             *input_asset_id,
@@ -519,7 +519,7 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
         amount: QuoteAmount<Balance>,
         deduce_fee: bool,
     ) -> Result<SwapOutcome<Balance>, DispatchError> {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(dex_id)?;
         // Get pool account.
         let (_, tech_acc_id) = Pallet::<T>::tech_account_from_dex_and_asset_pair(
             *dex_id,
@@ -640,20 +640,18 @@ use sp_runtime::traits::Zero;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use common::{AccountIdOf, Fixed, GetMarketInfo, OnPoolCreated};
+    use common::{AccountIdOf, DEXInfo, Fixed, GetMarketInfo, OnPoolCreated};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
     use orml_traits::GetByKey;
 
-    // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     // TODO: #395 use AssetInfoProvider instead of assets pallet
     // TODO: #441 use TradingPairSourceManager instead of trading-pair pallet
     #[pallet::config]
     pub trait Config:
         frame_system::Config
         + technical::Config
-        + dex_manager::Config
         + trading_pair::Config
         + ceres_liquidity_locker::Config
         + demeter_farming_platform::Config
@@ -683,6 +681,7 @@ pub mod pallet {
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
         type GetTradingPairRestrictedFlag: GetByKey<TradingPair<Self::AssetId>, bool>;
+        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
     }
 
     /// The current storage version.

--- a/pallets/pool-xyk/src/lib.rs
+++ b/pallets/pool-xyk/src/lib.rs
@@ -640,7 +640,7 @@ use sp_runtime::traits::Zero;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use common::{AccountIdOf, DEXInfo, Fixed, GetMarketInfo, OnPoolCreated};
+    use common::{AccountIdOf, Fixed, GetMarketInfo, OnPoolCreated};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
@@ -681,7 +681,6 @@ pub mod pallet {
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
         type GetTradingPairRestrictedFlag: GetByKey<TradingPair<Self::AssetId>, bool>;
-        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
     }
 
     /// The current storage version.

--- a/pallets/pool-xyk/src/mock.rs
+++ b/pallets/pool-xyk/src/mock.rs
@@ -336,6 +336,7 @@ impl Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = xst::Pallet<Runtime>;
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 #[allow(non_snake_case)]

--- a/pallets/pool-xyk/src/mock.rs
+++ b/pallets/pool-xyk/src/mock.rs
@@ -147,6 +147,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -242,6 +243,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {
@@ -336,7 +338,6 @@ impl Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = xst::Pallet<Runtime>;
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 #[allow(non_snake_case)]

--- a/pallets/pool-xyk/src/utils.rs
+++ b/pallets/pool-xyk/src/utils.rs
@@ -92,7 +92,6 @@ impl<T: Config> Pallet<T> {
         asset_a: T::AssetId,
         asset_b: T::AssetId,
     ) -> Result<(common::TradingPair<TechAssetIdOf<T>>, TechAccountIdOf<T>), DispatchError> {
-        // TODO: #392 use DexInfoProvider instead of dex-manager pallet
         let dexinfo = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let base_asset_id = dexinfo.base_asset_id;
         ensure!(asset_a != asset_b, Error::<T>::AssetsMustNotBeSame);

--- a/pallets/pool-xyk/src/utils.rs
+++ b/pallets/pool-xyk/src/utils.rs
@@ -37,7 +37,7 @@ use common::{
     AccountIdOf, DexInfoProvider, ToFeeAccount, ToXykTechUnitFromDEXAndTradingPair, TradingPair,
 };
 
-use crate::aliases::{AssetIdOf, DEXManager, TechAccountIdOf, TechAssetIdOf};
+use crate::aliases::{AssetIdOf, TechAccountIdOf, TechAssetIdOf};
 use crate::bounds::*;
 use crate::{Config, Error, Pallet, PoolProviders, TotalIssuances};
 
@@ -93,7 +93,7 @@ impl<T: Config> Pallet<T> {
         asset_b: T::AssetId,
     ) -> Result<(common::TradingPair<TechAssetIdOf<T>>, TechAccountIdOf<T>), DispatchError> {
         // TODO: #392 use DexInfoProvider instead of dex-manager pallet
-        let dexinfo = DEXManager::<T>::get_dex_info(&dex_id)?;
+        let dexinfo = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let base_asset_id = dexinfo.base_asset_id;
         ensure!(asset_a != asset_b, Error::<T>::AssetsMustNotBeSame);
         let ba = base_asset_id;

--- a/pallets/price-tools/src/mock.rs
+++ b/pallets/price-tools/src/mock.rs
@@ -292,6 +292,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/price-tools/src/mock.rs
+++ b/pallets/price-tools/src/mock.rs
@@ -156,6 +156,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -267,6 +268,7 @@ impl pswap_distribution::Config for Runtime {
     type WeightInfo = ();
     type GetParliamentAccountId = GetParliamentAccountId;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl demeter_farming_platform::Config for Runtime {
@@ -292,7 +294,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/price-tools/src/mock.rs
+++ b/pallets/price-tools/src/mock.rs
@@ -163,6 +163,7 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = ();
     type EnsureDEXManager = ();
     type EnsureTradingPairExists = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl Config for Runtime {

--- a/pallets/pswap-distribution/benchmarking/src/mock.rs
+++ b/pallets/pswap-distribution/benchmarking/src/mock.rs
@@ -299,6 +299,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/pswap-distribution/benchmarking/src/mock.rs
+++ b/pallets/pswap-distribution/benchmarking/src/mock.rs
@@ -186,6 +186,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl tokens::Config for Runtime {
@@ -273,6 +274,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -299,7 +301,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/pswap-distribution/src/lib.rs
+++ b/pallets/pswap-distribution/src/lib.rs
@@ -165,7 +165,7 @@ impl<T: Config> Pallet<T> {
         fees_account_id: &T::AccountId,
         dex_id: T::DEXId,
     ) -> DispatchResult {
-        let dex_info = dex_manager::Pallet::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         let base_total = Assets::<T>::free_balance(&dex_info.base_asset_id, &fees_account_id)?;
         if base_total == 0 {
             Self::deposit_event(Event::<T>::NothingToExchange(
@@ -436,21 +436,16 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use common::{AccountIdOf, PoolXykPallet};
+    use common::{AccountIdOf, DEXInfo, PoolXykPallet};
     use frame_support::pallet_prelude::*;
     use frame_support::sp_runtime::Percent;
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
 
-    // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     // TODO: #395 use AssetInfoProvider instead of assets pallet
     #[pallet::config]
     pub trait Config:
-        frame_system::Config
-        + common::Config
-        + assets::Config
-        + technical::Config
-        + dex_manager::Config
+        frame_system::Config + common::Config + assets::Config + technical::Config
     {
         const PSWAP_BURN_PERCENT: Percent;
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
@@ -471,6 +466,7 @@ pub mod pallet {
         type GetParliamentAccountId: Get<Self::AccountId>;
         type PoolXykPallet: PoolXykPallet<Self::AccountId, Self::AssetId>;
         type BuyBackHandler: BuyBackHandler<Self::AccountId, Self::AssetId>;
+        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
     }
 
     /// The current storage version.

--- a/pallets/pswap-distribution/src/mock.rs
+++ b/pallets/pswap-distribution/src/mock.rs
@@ -307,6 +307,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/pswap-distribution/src/mock.rs
+++ b/pallets/pswap-distribution/src/mock.rs
@@ -194,6 +194,7 @@ impl Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type BuyBackHandler = ();
     type PoolXykPallet = PoolXYK;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl tokens::Config for Runtime {
@@ -281,6 +282,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -307,7 +309,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = u64;

--- a/pallets/trading-pair/src/lib.rs
+++ b/pallets/trading-pair/src/lib.rs
@@ -56,7 +56,6 @@ mod tests;
 
 pub type TradingPair<T> = common::prelude::TradingPair<<T as assets::Config>::AssetId>;
 type Assets<T> = assets::Pallet<T>;
-type DEXManager<T> = dex_manager::Pallet<T>;
 
 pub use weights::WeightInfo;
 
@@ -80,7 +79,7 @@ impl<T: Config> TradingPairSourceManager<T::DEXId, T::AssetId> for Pallet<T> {
         &base_asset_id: &T::AssetId,
         &target_asset_id: &T::AssetId,
     ) -> Result<BTreeSet<LiquiditySourceType>, DispatchError> {
-        DEXManager::<T>::ensure_dex_exists(dex_id)?;
+        T::DexInfoProvider::ensure_dex_exists(dex_id)?;
         let pair = TradingPair::<T> {
             base_asset_id,
             target_asset_id,
@@ -156,7 +155,7 @@ impl<T: Config> Pallet<T> {
             Error::<T>::IdenticalAssetIds
         );
 
-        let dex_info = DEXManager::<T>::get_dex_info(&dex_id)?;
+        let dex_info = T::DexInfoProvider::get_dex_info(&dex_id)?;
         ensure!(
             base_asset_id == dex_info.base_asset_id
                 || base_asset_id == dex_info.synthetic_base_asset_id,
@@ -183,7 +182,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn list_trading_pairs(dex_id: &T::DEXId) -> Result<Vec<TradingPair<T>>, DispatchError> {
-        DEXManager::<T>::ensure_dex_exists(dex_id)?;
+        T::DexInfoProvider::ensure_dex_exists(dex_id)?;
         Ok(EnabledSources::<T>::iter_prefix(dex_id)
             .map(|(pair, _)| pair)
             .collect())
@@ -194,7 +193,7 @@ impl<T: Config> Pallet<T> {
         &base_asset_id: &T::AssetId,
         &target_asset_id: &T::AssetId,
     ) -> Result<bool, DispatchError> {
-        DEXManager::<T>::ensure_dex_exists(dex_id)?;
+        T::DexInfoProvider::ensure_dex_exists(dex_id)?;
         let pair = TradingPair::<T> {
             base_asset_id,
             target_asset_id,
@@ -208,12 +207,11 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use common::DexIdOf;
+    use common::{DEXInfo, DexIdOf};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::StorageVersion;
     use frame_system::pallet_prelude::*;
 
-    // TODO: #392 use DexInfoProvider instead of dex-manager pallet
     // TODO: #395 use AssetInfoProvider instead of assets pallet
     #[pallet::config]
     pub trait Config:
@@ -223,6 +221,7 @@ pub mod pallet {
         type EnsureDEXManager: EnsureDEXManager<Self::DEXId, Self::AccountId, DispatchError>;
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
+        type DexInfoProvider: DexInfoProvider<Self::DEXId, DEXInfo<Self::AssetId>>;
     }
 
     /// The current storage version.

--- a/pallets/trading-pair/src/mock.rs
+++ b/pallets/trading-pair/src/mock.rs
@@ -112,6 +112,7 @@ impl frame_system::Config for Runtime {
 impl Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 

--- a/pallets/vested-rewards/src/mock.rs
+++ b/pallets/vested-rewards/src/mock.rs
@@ -251,6 +251,7 @@ impl assets::Config for Runtime {
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -279,6 +280,7 @@ impl pswap_distribution::Config for Runtime {
     type PoolXykPallet = pool_xyk::Pallet<Runtime>;
     type GetParliamentAccountId = GetParliamentAccountId;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl demeter_farming_platform::Config for Runtime {
@@ -304,7 +306,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl multicollateral_bonding_curve_pool::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;

--- a/pallets/vested-rewards/src/mock.rs
+++ b/pallets/vested-rewards/src/mock.rs
@@ -304,6 +304,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl multicollateral_bonding_curve_pool::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;

--- a/pallets/xor-fee/src/mock.rs
+++ b/pallets/xor-fee/src/mock.rs
@@ -364,6 +364,7 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl dex_manager::Config for Runtime {}

--- a/pallets/xor-fee/src/mock.rs
+++ b/pallets/xor-fee/src/mock.rs
@@ -372,6 +372,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -493,6 +494,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pool_xyk::Config for Runtime {
@@ -511,7 +513,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl ceres_liquidity_locker::Config for Runtime {
     const BLOCKS_PER_ONE_DAY: BlockNumberFor<Self> = 14_440;

--- a/pallets/xor-fee/src/mock.rs
+++ b/pallets/xor-fee/src/mock.rs
@@ -511,6 +511,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl ceres_liquidity_locker::Config for Runtime {
     const BLOCKS_PER_ONE_DAY: BlockNumberFor<Self> = 14_440;

--- a/pallets/xst/benchmarking/src/mock.rs
+++ b/pallets/xst/benchmarking/src/mock.rs
@@ -344,6 +344,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = Moment;

--- a/pallets/xst/benchmarking/src/mock.rs
+++ b/pallets/xst/benchmarking/src/mock.rs
@@ -172,6 +172,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -272,7 +273,6 @@ impl dex_api::Config for Runtime {
     type XYKPool = MockLiquiditySource;
     type XSTPool = XSTPool;
     type MulticollateralBondingCurvePool = ();
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
@@ -319,6 +319,7 @@ impl pswap_distribution::Config for Runtime {
     type PoolXykPallet = PoolXYK;
     type GetXSTAssetId = GetSyntheticBaseAssetId;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl demeter_farming_platform::Config for Runtime {
@@ -344,7 +345,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 impl pallet_timestamp::Config for Runtime {
     type Moment = Moment;

--- a/pallets/xst/benchmarking/src/mock.rs
+++ b/pallets/xst/benchmarking/src/mock.rs
@@ -179,6 +179,7 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = ();
     type EnsureDEXManager = ();
     type EnsureTradingPairExists = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl xst::Config for Runtime {

--- a/pallets/xst/benchmarking/src/mock.rs
+++ b/pallets/xst/benchmarking/src/mock.rs
@@ -271,6 +271,7 @@ impl dex_api::Config for Runtime {
     type XYKPool = MockLiquiditySource;
     type XSTPool = XSTPool;
     type MulticollateralBondingCurvePool = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();

--- a/pallets/xst/src/mock.rs
+++ b/pallets/xst/src/mock.rs
@@ -173,6 +173,7 @@ impl dex_manager::Config for Runtime {}
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -273,7 +274,6 @@ impl dex_api::Config for Runtime {
     type XYKPool = MockLiquiditySource;
     type XSTPool = XSTPool;
     type MulticollateralBondingCurvePool = ();
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();
@@ -320,6 +320,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl price_tools::Config for Runtime {
@@ -351,7 +352,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/xst/src/mock.rs
+++ b/pallets/xst/src/mock.rs
@@ -272,6 +272,7 @@ impl dex_api::Config for Runtime {
     type XYKPool = MockLiquiditySource;
     type XSTPool = XSTPool;
     type MulticollateralBondingCurvePool = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 
     #[cfg(feature = "ready-to-test")] // order-book
     type OrderBook = ();

--- a/pallets/xst/src/mock.rs
+++ b/pallets/xst/src/mock.rs
@@ -351,6 +351,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = ();
     type XSTMarketInfo = ();
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/pallets/xst/src/mock.rs
+++ b/pallets/xst/src/mock.rs
@@ -180,6 +180,7 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = ();
     type EnsureDEXManager = ();
     type EnsureTradingPairExists = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1037,6 +1037,7 @@ impl liquidity_proxy::Config for Runtime {
         pallet_collective::EnsureProportionMoreThan<AccountId, TechnicalCollective, 1, 2>,
         EnsureRoot<AccountId>,
     >;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -934,6 +934,7 @@ impl assets::Config for Runtime {
 impl trading_pair::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type WeightInfo = ();
 }
 
@@ -985,7 +986,6 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = pool_xyk::weights::SubstrateWeight<Runtime>;
     type XSTMarketInfo = XSTPool;
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 parameter_types! {
@@ -1038,7 +1038,6 @@ impl liquidity_proxy::Config for Runtime {
         pallet_collective::EnsureProportionMoreThan<AccountId, TechnicalCollective, 1, 2>,
         EnsureRoot<AccountId>,
     >;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime {
@@ -1079,7 +1078,6 @@ impl dex_api::Config for Runtime {
     type MockLiquiditySource4 =
         mock_liquidity_source::Pallet<Runtime, mock_liquidity_source::Instance4>;
     type MulticollateralBondingCurvePool = multicollateral_bonding_curve_pool::Pallet<Runtime>;
-    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = xst::Pallet<Runtime>;
 
@@ -1726,6 +1724,7 @@ impl pswap_distribution::Config for Runtime {
     type GetParliamentAccountId = GetParliamentAccountId;
     type PoolXykPallet = PoolXYK;
     type BuyBackHandler = liquidity_proxy::LiquidityProxyBuyBackHandler<Runtime, GetBuyBackDexId>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1073,6 +1073,7 @@ impl dex_api::Config for Runtime {
     type MockLiquiditySource4 =
         mock_liquidity_source::Pallet<Runtime, mock_liquidity_source::Instance4>;
     type MulticollateralBondingCurvePool = multicollateral_bonding_curve_pool::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
     type XYKPool = pool_xyk::Pallet<Runtime>;
     type XSTPool = xst::Pallet<Runtime>;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1044,24 +1044,28 @@ impl mock_liquidity_source::Config<mock_liquidity_source::Instance1> for Runtime
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance2> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance3> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl mock_liquidity_source::Config<mock_liquidity_source::Instance4> for Runtime {
     type GetFee = GetFee;
     type EnsureDEXManager = dex_manager::Pallet<Runtime>;
     type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 impl dex_api::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -985,6 +985,7 @@ impl pool_xyk::Config for Runtime {
     type WeightInfo = pool_xyk::weights::SubstrateWeight<Runtime>;
     type XSTMarketInfo = XSTPool;
     type GetTradingPairRestrictedFlag = GetTradingPairRestrictedFlag;
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
 }
 
 parameter_types! {


### PR DESCRIPTION
# Changes
- Replaced dex_manager's methods calls with relevant DexInfoProvider trait methods
- Replaced assets' methods calls with relevant AssetInfoProvider trait methods