### PR TITLE
Use clippy by default and disable warnings

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -29,6 +29,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 #[macro_use]
 extern crate alloc;
 

--- a/housekeeping/build.sh
+++ b/housekeeping/build.sh
@@ -51,9 +51,9 @@ else
     rm -rf ~/.cargo/.package-cache
     rm Cargo.lock
     cargo fmt -- --check > /dev/null
-    SKIP_WASM_BUILD=1 cargo check
-    SKIP_WASM_BUILD=1 cargo check --features private-net,ready-to-test
-    SKIP_WASM_BUILD=1 cargo check --features private-net,ready-to-test,wip
+    SKIP_WASM_BUILD=1 cargo clippy
+    SKIP_WASM_BUILD=1 cargo clippy --features private-net,ready-to-test,runtime-benchmarks
+    SKIP_WASM_BUILD=1 cargo clippy --features private-net,ready-to-test,wip,runtime-benchmarks
     cargo test
     cargo test --features "private-net wip ready-to-test runtime-benchmarks"
 fi

--- a/node/chain_spec/src/lib.rs
+++ b/node/chain_spec/src/lib.rs
@@ -34,6 +34,8 @@
 //   specified, we have to rely on such constructions.
 
 #![allow(unused_imports, unused_macros, dead_code)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::prelude::{Balance, DEXInfo, FixedWrapper};
 use common::{

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -30,6 +30,8 @@
 
 //! Substrate Node Template CLI library.
 #![warn(missing_docs)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[macro_use]
 mod service;

--- a/pallets/assets/src/lib.rs
+++ b/pallets/assets/src/lib.rs
@@ -41,6 +41,8 @@
 //! - `register` - registers new asset by a given ID.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/pallets/band/src/lib.rs
+++ b/pallets/band/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::prelude::FixedWrapper;
 use common::{fixed, fixed_wrapper, Balance, DataFeed, Fixed, OnNewSymbolsRelayed, Oracle, Rate};

--- a/pallets/ceres-governance-platform/src/lib.rs
+++ b/pallets/ceres-governance-platform/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod migrations;
 pub mod weights;

--- a/pallets/ceres-launchpad/src/lib.rs
+++ b/pallets/ceres-launchpad/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod weights;
 

--- a/pallets/ceres-liquidity-locker/benchmarking/src/lib.rs
+++ b/pallets/ceres-liquidity-locker/benchmarking/src/lib.rs
@@ -1,6 +1,8 @@
 //! Ceres liquidity locker module benchmarking.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use ceres_liquidity_locker::AccountIdOf;
 use codec::Decode;

--- a/pallets/ceres-liquidity-locker/src/lib.rs
+++ b/pallets/ceres-liquidity-locker/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[cfg(test)]
 mod mock;

--- a/pallets/ceres-staking/src/lib.rs
+++ b/pallets/ceres-staking/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod weights;
 

--- a/pallets/ceres-token-locker/src/lib.rs
+++ b/pallets/ceres-token-locker/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod migrations;
 pub mod weights;

--- a/pallets/demeter-farming-platform/benchmarking/src/lib.rs
+++ b/pallets/demeter-farming-platform/benchmarking/src/lib.rs
@@ -1,6 +1,8 @@
 //! Demeter farming platform module benchmarking.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use codec::Decode;
 use common::{

--- a/pallets/demeter-farming-platform/src/lib.rs
+++ b/pallets/demeter-farming-platform/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod migrations;
 pub mod weights;

--- a/pallets/dex-api/rpc/src/lib.rs
+++ b/pallets/dex-api/rpc/src/lib.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 use codec::Codec;
 use common::BalanceWrapper;
 use jsonrpsee::{

--- a/pallets/dex-api/src/lib.rs
+++ b/pallets/dex-api/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::prelude::{Balance, QuoteAmount, SwapAmount, SwapOutcome};
 use common::{

--- a/pallets/dex-manager/src/lib.rs
+++ b/pallets/dex-manager/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use assets::AssetIdOf;
 use common::prelude::EnsureDEXManager;

--- a/pallets/eth-bridge/rpc/src/lib.rs
+++ b/pallets/eth-bridge/rpc/src/lib.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 use codec::Codec;
 pub use eth_bridge_runtime_api::EthBridgeRuntimeApi;
 use jsonrpsee::{

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -31,6 +31,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::unnecessary_mut_passed)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use codec::Codec;
 use sp_runtime::DispatchError;

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -29,8 +29,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::unnecessary_mut_passed)]
 // TODO #167: fix clippy warnings
 #![allow(clippy::all)]
 

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -65,6 +65,8 @@ Persists the same multi-sig account (+- 1 signatory) for validating all its inco
 */
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[macro_use]
 extern crate alloc;

--- a/pallets/farming/src/lib.rs
+++ b/pallets/farming/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/pallets/faucet/src/lib.rs
+++ b/pallets/faucet/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::{balance, AssetInfoProvider, Balance, HERMES_ASSET_ID, PSWAP, VAL, XOR};
 use frame_support::ensure;

--- a/pallets/hermes-governance-platform/src/lib.rs
+++ b/pallets/hermes-governance-platform/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 mod benchmarking;
 pub mod migrations;

--- a/pallets/iroha-migration/src/lib.rs
+++ b/pallets/iroha-migration/src/lib.rs
@@ -36,6 +36,8 @@
 //! All migrated accounts are stored to use when their referrals migrate or when a user attempts to migrate again
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[macro_use]
 extern crate alloc;

--- a/pallets/liquidity-proxy/rpc/src/lib.rs
+++ b/pallets/liquidity-proxy/rpc/src/lib.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 use codec::Codec;
 use common::BalanceWrapper;
 use jsonrpsee::{

--- a/pallets/liquidity-proxy/src/lib.rs
+++ b/pallets/liquidity-proxy/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 extern crate core;
 

--- a/pallets/mock-liquidity-source/src/lib.rs
+++ b/pallets/mock-liquidity-source/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::fixnum::ops::One;
 use common::prelude::{FixedWrapper, QuoteAmount, SwapAmount, SwapOutcome};

--- a/pallets/multicollateral-bonding-curve-pool/src/lib.rs
+++ b/pallets/multicollateral-bonding-curve-pool/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod weights;
 

--- a/pallets/oracle-proxy/src/lib.rs
+++ b/pallets/oracle-proxy/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::{DataFeed, OnNewSymbolsRelayed, Oracle, Rate};
 use frame_support;

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -30,6 +30,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)] // todo (m.tagirov) remove
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use assets::AssetIdOf;
 use common::prelude::{

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -45,6 +45,8 @@
     variant_size_differences
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use frame_support::codec::{Decode, Encode};
 use frame_support::{ensure, RuntimeDebug};

--- a/pallets/pool-xyk/benchmarking/src/lib.rs
+++ b/pallets/pool-xyk/benchmarking/src/lib.rs
@@ -32,6 +32,8 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use codec::Decode;
 use common::prelude::{Balance, SwapAmount};

--- a/pallets/pool-xyk/src/lib.rs
+++ b/pallets/pool-xyk/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::storage::PrefixIterator;

--- a/pallets/price-tools/src/lib.rs
+++ b/pallets/price-tools/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod weights;
 

--- a/pallets/pswap-distribution/benchmarking/src/lib.rs
+++ b/pallets/pswap-distribution/benchmarking/src/lib.rs
@@ -32,6 +32,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg(feature = "runtime-benchmarks")]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[cfg(test)]
 mod mock;

--- a/pallets/pswap-distribution/src/lib.rs
+++ b/pallets/pswap-distribution/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::fixnum::ops::{CheckedAdd, CheckedSub};
 use common::prelude::{Balance, FixedWrapper, SwapAmount};

--- a/pallets/qa-tools/src/lib.rs
+++ b/pallets/qa-tools/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub use pallet::*;
 

--- a/pallets/referrals/src/lib.rs
+++ b/pallets/referrals/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -36,6 +36,8 @@
 //! * PSWAP NFT waifus
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use frame_support::codec::{Decode, Encode};
 use frame_support::dispatch::DispatchErrorWithPostInfo;

--- a/pallets/technical/src/lib.rs
+++ b/pallets/technical/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use codec::{Decode, Encode};
 use common::prelude::Balance;

--- a/pallets/trading-pair/src/lib.rs
+++ b/pallets/trading-pair/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/pallets/trustless-bridge/bridge-inbound-channel/src/lib.rs
+++ b/pallets/trustless-bridge/bridge-inbound-channel/src/lib.rs
@@ -1,6 +1,8 @@
 //! Channel for passing messages from ethereum to substrate.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use bridge_types::evm::{AdditionalEVMInboundData, AdditionalEVMOutboundData};
 use bridge_types::traits::{MessageDispatch, Verifier};

--- a/pallets/trustless-bridge/bridge-outbound-channel/src/lib.rs
+++ b/pallets/trustless-bridge/bridge-outbound-channel/src/lib.rs
@@ -1,6 +1,8 @@
 //! Channel for passing messages from substrate to ethereum.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use bridge_types::{H256, U256};
 use codec::Encode;

--- a/pallets/trustless-bridge/bridge-proxy/src/lib.rs
+++ b/pallets/trustless-bridge/bridge-proxy/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[cfg(test)]
 mod mock;

--- a/pallets/trustless-bridge/erc20-app/src/lib.rs
+++ b/pallets/trustless-bridge/erc20-app/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! - `burn`: Burn an ERC20 token balance.
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub const TRANSFER_MAX_GAS: u64 = 100_000;
 

--- a/pallets/trustless-bridge/eth-app/src/lib.rs
+++ b/pallets/trustless-bridge/eth-app/src/lib.rs
@@ -15,6 +15,8 @@
 //! - `burn`: Burn an ETH balance.
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub const TRANSFER_MAX_GAS: u64 = 100_000;
 

--- a/pallets/trustless-bridge/ethereum-light-client/src/lib.rs
+++ b/pallets/trustless-bridge/ethereum-light-client/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 #![allow(unused_variables)]
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 mod weights;
 

--- a/pallets/trustless-bridge/migration-app/src/lib.rs
+++ b/pallets/trustless-bridge/migration-app/src/lib.rs
@@ -15,6 +15,8 @@
 //! - `burn`: Burn an ETH balance.
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use frame_support::dispatch::DispatchResult;
 use frame_support::weights::Weight;

--- a/pallets/vested-rewards/src/lib.rs
+++ b/pallets/vested-rewards/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/pallets/xor-fee/src/lib.rs
+++ b/pallets/xor-fee/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use common::prelude::SwapAmount;
 use common::{

--- a/pallets/xst/benchmarking/src/lib.rs
+++ b/pallets/xst/benchmarking/src/lib.rs
@@ -32,6 +32,8 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 use assets::Event as AssetsEvent;
 use band::Pallet as Band;

--- a/pallets/xst/src/lib.rs
+++ b/pallets/xst/src/lib.rs
@@ -29,6 +29,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 pub mod weights;
 

--- a/relayer/ethereum-gen/src/lib.rs
+++ b/relayer/ethereum-gen/src/lib.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 ethers::contract::abigen!(
     InboundChannel,
     "src/bytes/InboundChannel.abi.json",

--- a/relayer/parachain-gen/build.rs
+++ b/relayer/parachain-gen/build.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 extern crate reqwest;
 
 use std::path::PathBuf;

--- a/relayer/parachain-gen/src/lib.rs
+++ b/relayer/parachain-gen/src/lib.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 pub type MaxU32 = sp_runtime::traits::ConstU32<{ core::u32::MAX }>;
 pub type UnboundedBridgeMessage = bridge_types::substrate::BridgeMessage<MaxU32>;
 pub type UnboundedGenericCommitment = bridge_types::GenericCommitment<MaxU32, MaxU32>;

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 mod cli;
 mod ethereum;
 mod relay;

--- a/relayer/substrate-gen/src/lib.rs
+++ b/relayer/substrate-gen/src/lib.rs
@@ -28,6 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 #[macro_use]
 extern crate codec;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,6 +31,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
 
 extern crate alloc;
 use alloc::string::String;

--- a/utils/remote-ext/src/main.rs
+++ b/utils/remote-ext/src/main.rs
@@ -1,3 +1,6 @@
+// TODO #167: fix clippy warnings
+#![allow(clippy::all)]
+
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
This PR include clippy to CI and disable clippy warnings for all crates. We should fix and enable this warnings in separate PRs