### PR TITLE
OrderBook: market maker network fee

### DIFF
--- a/pallets/order-book/src/fee_calculator.rs
+++ b/pallets/order-book/src/fee_calculator.rs
@@ -50,8 +50,14 @@ impl<T: Config> FeeCalculator<T> {
     ///
     /// const part = (4 / 7) * (base fee / 2)
     /// dynamic part = (3 / 7) * (base fee / 2) * (lifetime / max_lifetime)
-    pub fn place_limit_order_fee(lifetime: Option<u64>, is_err: bool) -> Option<Balance> {
-        if is_err {
+    pub fn place_limit_order_fee(
+        lifetime: Option<u64>,
+        has_weight: bool,
+        is_err: bool,
+    ) -> Option<Balance> {
+        // if place_limit_order() returns weight, it means that the limit order was converted into market order and the exchange fee should be taken
+        // if some error occurred, it means we don't prvide the reduced market maker fee for this call
+        if has_weight || is_err {
             return Some(BASE_FEE);
         }
 

--- a/pallets/order-book/src/fee_calculator.rs
+++ b/pallets/order-book/src/fee_calculator.rs
@@ -28,7 +28,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{Config, MomentOf};
+use crate::Config;
 use common::prelude::FixedWrapper;
 use common::Balance;
 use sp_std::marker::PhantomData;
@@ -50,7 +50,7 @@ impl<T: Config> FeeCalculator<T> {
     ///
     /// const part = (4 / 7) * (base fee / 2)
     /// dynamic part = (3 / 7) * (base fee / 2) * (lifetime / max_lifetime)
-    pub fn place_limit_order_fee(lifetime: Option<MomentOf<T>>, is_err: bool) -> Option<Balance> {
+    pub fn place_limit_order_fee(lifetime: Option<u64>, is_err: bool) -> Option<Balance> {
         if is_err {
             return Some(BASE_FEE);
         }
@@ -61,7 +61,6 @@ impl<T: Config> FeeCalculator<T> {
             return Some(market_maker_max_fee);
         };
 
-        let lifetime: u64 = lifetime.try_into().ok()?;
         let max_lifetime: u64 = T::MAX_ORDER_LIFESPAN.try_into().ok()?;
 
         let life_ratio = FixedWrapper::from(lifetime) / FixedWrapper::from(max_lifetime);

--- a/pallets/order-book/src/fee_calculator.rs
+++ b/pallets/order-book/src/fee_calculator.rs
@@ -63,6 +63,7 @@ impl<T: Config> FeeCalculator<T> {
 
         let market_maker_max_fee = BASE_FEE.checked_div(2)?;
 
+        // Maximum lifetime is used if `None` was supplied
         let Some(lifetime) = lifetime else {
             return Some(market_maker_max_fee);
         };

--- a/pallets/order-book/src/fee_calculator.rs
+++ b/pallets/order-book/src/fee_calculator.rs
@@ -28,11 +28,50 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod data_layer;
-mod extrinsics;
-mod fee_calculator;
-mod order_book;
-mod orders;
-mod pallet;
-mod test_utils;
-mod types;
+use crate::{Config, MomentOf};
+use common::prelude::FixedWrapper;
+use common::Balance;
+use sp_std::marker::PhantomData;
+
+use common::prelude::constants::SMALL_FEE as BASE_FEE;
+
+/// Calculator for order book custom fees
+pub struct FeeCalculator<T: Config>(PhantomData<T>);
+
+impl<T: Config> FeeCalculator<T> {
+    /// Calculates the fee for `place_limit_order` extrinsic.
+    ///
+    /// The idea is to provide the reduced fee for market maker.
+    /// If extrinsic is successfull, user pays maximum half network fee.
+    /// If extrinsic failed, user pays full network fee.
+    ///
+    /// The actual fee contains two parts: constant and dynamic.
+    /// Dynamic part depends on limit order lifetime. The longer the lifetime, the higher the dynamic fee.
+    ///
+    /// const part = (4 / 7) * (base fee / 2)
+    /// dynamic part = (3 / 7) * (base fee / 2) * (lifetime / max_lifetime)
+    pub fn place_limit_order_fee(lifetime: Option<MomentOf<T>>, is_err: bool) -> Option<Balance> {
+        if is_err {
+            return Some(BASE_FEE);
+        }
+
+        let market_maker_max_fee = BASE_FEE.checked_div(2)?;
+
+        let Some(lifetime) = lifetime else {
+            return Some(market_maker_max_fee);
+        };
+
+        let lifetime: u64 = lifetime.try_into().ok()?;
+        let max_lifetime: u64 = T::MAX_ORDER_LIFESPAN.try_into().ok()?;
+
+        let life_ratio = FixedWrapper::from(lifetime) / FixedWrapper::from(max_lifetime);
+
+        let const_part = (FixedWrapper::from(market_maker_max_fee) / FixedWrapper::from(7))
+            * FixedWrapper::from(4);
+        let dynamic_part = (FixedWrapper::from(market_maker_max_fee) / FixedWrapper::from(7))
+            * FixedWrapper::from(3)
+            * life_ratio;
+
+        (const_part + dynamic_part).try_into_balance().ok()
+    }
+}

--- a/pallets/order-book/src/fee_calculator.rs
+++ b/pallets/order-book/src/fee_calculator.rs
@@ -55,9 +55,9 @@ impl<T: Config> FeeCalculator<T> {
         has_weight: bool,
         is_err: bool,
     ) -> Option<Balance> {
-        // if place_limit_order() returns weight, it means that the limit order was converted into market order and the exchange fee should be taken
+        // if place_limit_order() doesn't return a weight, it means that the limit order was converted into market order and the exchange fee should be taken
         // if some error occurred, it means we don't prvide the reduced market maker fee for this call
-        if has_weight || is_err {
+        if !has_weight || is_err {
             return Some(BASE_FEE);
         }
 

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -1073,7 +1073,8 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
 
         ensure!(deal_info.is_valid(), Error::<T>::PriceCalculationFailed);
 
-        let fee = 0; // todo (m.tagirov)
+        // order-book doesn't take fee
+        let fee = Balance::zero();
 
         match amount {
             QuoteAmount::WithDesiredInput { .. } => Ok((
@@ -1141,7 +1142,8 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
         let (input_amount, output_amount) =
             order_book.execute_market_order(market_order, &mut data)?;
 
-        let fee = 0; // todo (m.tagirov)
+        // order-book doesn't take fee
+        let fee = Balance::zero();
 
         let result = match desired_amount {
             SwapAmount::WithDesiredInput { min_amount_out, .. } => {
@@ -1254,7 +1256,8 @@ impl<T: Config> LiquiditySource<T::DEXId, T::AccountId, T::AssetId, Balance, Dis
             Error::<T>::InvalidOrderAmount
         );
 
-        let fee = 0; // todo (m.tagirov)
+        // order-book doesn't take fee
+        let fee = Balance::zero();
 
         Ok(SwapOutcome::new(*target_amount.balance(), fee))
     }

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -66,6 +66,7 @@ mod tests;
 mod benchmarking;
 
 pub mod cache_data_layer;
+pub mod fee_calculator;
 mod limit_order;
 mod market_order;
 mod order_book;

--- a/pallets/order-book/src/tests/fee_calculator.rs
+++ b/pallets/order-book/src/tests/fee_calculator.rs
@@ -30,7 +30,6 @@
 
 #![cfg(feature = "wip")] // order-book
 
-//use crate::fee_calculator::FeeCalculator;
 use common::balance;
 use common::prelude::constants::SMALL_FEE;
 use framenode_runtime::order_book::fee_calculator::FeeCalculator;

--- a/pallets/order-book/src/tests/fee_calculator.rs
+++ b/pallets/order-book/src/tests/fee_calculator.rs
@@ -28,11 +28,61 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod data_layer;
-mod extrinsics;
-mod fee_calculator;
-mod order_book;
-mod orders;
-mod pallet;
-mod test_utils;
-mod types;
+#![cfg(feature = "wip")] // order-book
+
+//use crate::fee_calculator::FeeCalculator;
+use common::balance;
+use common::prelude::constants::SMALL_FEE;
+use framenode_runtime::order_book::fee_calculator::FeeCalculator;
+use framenode_runtime::order_book::Config;
+use framenode_runtime::Runtime;
+
+#[test]
+fn should_calculate_place_limit_order_fee() {
+    let max_lifetime = <Runtime as Config>::MAX_ORDER_LIFESPAN;
+
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false).unwrap(),
+        balance!(0.0002)
+    );
+
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 10), false).unwrap(),
+        balance!(0.000215)
+    );
+
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 5), false).unwrap(),
+        balance!(0.00023)
+    );
+
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 2), false).unwrap(),
+        balance!(0.000275)
+    );
+
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime), false).unwrap(),
+        SMALL_FEE / 2
+    );
+}
+
+#[test]
+fn should_calculate_place_limit_order_fee_with_error() {
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), true).unwrap(),
+        SMALL_FEE
+    );
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), true).unwrap(),
+        SMALL_FEE
+    );
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), true).unwrap(),
+        SMALL_FEE
+    );
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(None, true).unwrap(),
+        SMALL_FEE
+    );
+}

--- a/pallets/order-book/src/tests/fee_calculator.rs
+++ b/pallets/order-book/src/tests/fee_calculator.rs
@@ -41,47 +41,72 @@ fn should_calculate_place_limit_order_fee() {
     let max_lifetime = <Runtime as Config>::MAX_ORDER_LIFESPAN;
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false, false).unwrap(),
         balance!(0.0002)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 10), false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 10), false, false)
+            .unwrap(),
         balance!(0.000215)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 5), false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 5), false, false)
+            .unwrap(),
         balance!(0.00023)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 2), false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 2), false, false)
+            .unwrap(),
         balance!(0.000275)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime), false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime), false, false).unwrap(),
         SMALL_FEE / 2
+    );
+}
+
+#[test]
+fn should_calculate_place_limit_order_fee_with_weight() {
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), true, false).unwrap(),
+        SMALL_FEE
+    );
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), true, false).unwrap(),
+        SMALL_FEE
+    );
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), true, false)
+            .unwrap(),
+        SMALL_FEE
+    );
+    assert_eq!(
+        FeeCalculator::<Runtime>::place_limit_order_fee(None, true, false).unwrap(),
+        SMALL_FEE
     );
 }
 
 #[test]
 fn should_calculate_place_limit_order_fee_with_error() {
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), false, true).unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false, true).unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), false, true)
+            .unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(None, true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(None, false, true).unwrap(),
         SMALL_FEE
     );
 }

--- a/pallets/order-book/src/tests/fee_calculator.rs
+++ b/pallets/order-book/src/tests/fee_calculator.rs
@@ -41,51 +41,51 @@ fn should_calculate_place_limit_order_fee() {
     let max_lifetime = <Runtime as Config>::MAX_ORDER_LIFESPAN;
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false, false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), true, false).unwrap(),
         balance!(0.0002)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 10), false, false)
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 10), true, false)
             .unwrap(),
         balance!(0.000215)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 5), false, false)
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 5), true, false)
             .unwrap(),
         balance!(0.00023)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 2), false, false)
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime / 2), true, false)
             .unwrap(),
         balance!(0.000275)
     );
 
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime), false, false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(max_lifetime), true, false).unwrap(),
         SMALL_FEE / 2
     );
 }
 
 #[test]
-fn should_calculate_place_limit_order_fee_with_weight() {
+fn should_calculate_place_limit_order_fee_without_weight() {
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), true, false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), false, false).unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), true, false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false, false).unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), true, false)
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), false, false)
             .unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(None, true, false).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(None, false, false).unwrap(),
         SMALL_FEE
     );
 }
@@ -93,20 +93,20 @@ fn should_calculate_place_limit_order_fee_with_weight() {
 #[test]
 fn should_calculate_place_limit_order_fee_with_error() {
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), false, true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000), true, true).unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), false, true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(0), true, true).unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), false, true)
+        FeeCalculator::<Runtime>::place_limit_order_fee(Some(1000000000000000), true, true)
             .unwrap(),
         SMALL_FEE
     );
     assert_eq!(
-        FeeCalculator::<Runtime>::place_limit_order_fee(None, false, true).unwrap(),
+        FeeCalculator::<Runtime>::place_limit_order_fee(None, true, true).unwrap(),
         SMALL_FEE
     );
 }

--- a/pallets/order-book/src/tests/pallet.rs
+++ b/pallets/order-book/src/tests/pallet.rs
@@ -1120,7 +1120,6 @@ fn should_quote() {
             SwapOutcome::new(balance!(251.66326).into(), 0)
         );
 
-        // todo (m.tagirov) remake when fee introduced
         // with fee
         assert_eq!(
             OrderBookPallet::quote(
@@ -1390,7 +1389,6 @@ fn should_quote_without_impact() {
             SwapOutcome::new(balance!(250).into(), 0)
         );
 
-        // todo (m.tagirov) remake when fee introduced
         // with fee
         assert_eq!(
             OrderBookPallet::quote_without_impact(

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -1,3 +1,33 @@
+// This file is part of the SORA network and Polkaswap app.
+
+// Copyright (c) 2020, 2021, Polka Biome Ltd. All rights reserved.
+// SPDX-License-Identifier: BSD-4-Clause
+
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+//
+// All advertising materials mentioning features or use of this software must display
+// the following acknowledgement: This product includes software developed by Polka Biome
+// Ltd., SORA, and Polkaswap.
+//
+// Neither the name of the Polka Biome Ltd. nor the names of its contributors may be used
+// to endorse or promote products derived from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY Polka Biome Ltd. AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Polka Biome Ltd. BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use crate::*;
 use bridge_types::GenericNetworkId;
 use sp_runtime::traits::Zero;

--- a/runtime/src/mock.rs
+++ b/runtime/src/mock.rs
@@ -1,3 +1,33 @@
+// This file is part of the SORA network and Polkaswap app.
+
+// Copyright (c) 2020, 2021, Polka Biome Ltd. All rights reserved.
+// SPDX-License-Identifier: BSD-4-Clause
+
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+//
+// All advertising materials mentioning features or use of this software must display
+// the following acknowledgement: This product includes software developed by Polka Biome
+// Ltd., SORA, and Polkaswap.
+//
+// Neither the name of the Polka Biome Ltd. nor the names of its contributors may be used
+// to endorse or promote products derived from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY Polka Biome Ltd. AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Polka Biome Ltd. BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use common::mock::alice;
 use common::PriceVariant;
 use price_tools::AVG_BLOCK_SPAN;

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -987,7 +987,7 @@ fn withdraw_fee_place_limit_order_with_default_lifetime() {
         assert!(ChargeTransactionPayment::<Runtime>::post_dispatch(
             Some(pre),
             &dispatch_info,
-            &default_post_info(),
+            &post_info_from_weight(MOCK_WEIGHT),
             len,
             &Ok(())
         )
@@ -1033,7 +1033,7 @@ fn withdraw_fee_place_limit_order_with_some_lifetime() {
         assert!(ChargeTransactionPayment::<Runtime>::post_dispatch(
             Some(pre),
             &dispatch_info,
-            &default_post_info(),
+            &post_info_from_weight(MOCK_WEIGHT),
             len,
             &Ok(())
         )
@@ -1079,7 +1079,7 @@ fn withdraw_fee_place_limit_order_with_error() {
         assert!(ChargeTransactionPayment::<Runtime>::post_dispatch(
             Some(pre),
             &dispatch_info,
-            &default_post_info(),
+            &post_info_from_weight(MOCK_WEIGHT),
             len,
             &Err(order_book::Error::<Runtime>::InvalidLimitOrderPrice.into())
         )
@@ -1125,7 +1125,7 @@ fn withdraw_fee_place_limit_order_with_crossing_spread() {
         assert!(ChargeTransactionPayment::<Runtime>::post_dispatch(
             Some(pre),
             &dispatch_info,
-            &post_info_from_weight(MOCK_WEIGHT), // some weight means that the limit was converted into market order
+            &default_post_info(), // none weight means that the limit was converted into market order
             len,
             &Ok(())
         )

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -1095,7 +1095,6 @@ fn withdraw_fee_place_limit_order_with_error() {
 }
 
 #[cfg(feature = "wip")] // order-book
-#[ignore] // todo fix
 #[test]
 fn withdraw_fee_place_limit_order_with_crossing_spread() {
     ext().execute_with(|| {

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -927,7 +927,7 @@ fn it_works_eth_bridge_pays_no() {
 
 #[cfg(feature = "wip")] // order-book
 #[test]
-fn fee_postponed_place_limit_order() {
+fn fee_not_postponed_place_limit_order() {
     ext().execute_with(|| {
         set_weight_to_fee_multiplier(1);
         give_xor_initial_balance(alice());
@@ -952,7 +952,10 @@ fn fee_postponed_place_limit_order() {
             xor_fee::Pallet::<Runtime>::withdraw_fee(&alice(), &call, &dispatch_info, SMALL_FEE, 0)
                 .unwrap();
 
-        assert_eq!(quoted_fee, LiquidityInfo::Postponed(alice()));
+        assert_eq!(
+            quoted_fee,
+            LiquidityInfo::Paid(alice(), Some(NegativeImbalance::new(SMALL_FEE)))
+        );
     });
 }
 

--- a/runtime/src/xor_fee_impls.rs
+++ b/runtime/src/xor_fee_impls.rs
@@ -270,6 +270,7 @@ impl xor_fee::ApplyCustomFees<RuntimeCall, AccountId> for CustomFees {
             CustomFeeDetails::LimitOrderLifetime(lifetime) => {
                 order_book::fee_calculator::FeeCalculator::<Runtime>::place_limit_order_fee(
                     lifetime,
+                    _post_info.actual_weight.is_some(),
                     _result.is_err(),
                 )
             }

--- a/runtime/src/xor_fee_impls.rs
+++ b/runtime/src/xor_fee_impls.rs
@@ -1,3 +1,33 @@
+// This file is part of the SORA network and Polkaswap app.
+
+// Copyright (c) 2020, 2021, Polka Biome Ltd. All rights reserved.
+// SPDX-License-Identifier: BSD-4-Clause
+
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+//
+// All advertising materials mentioning features or use of this software must display
+// the following acknowledgement: This product includes software developed by Polka Biome
+// Ltd., SORA, and Polkaswap.
+//
+// Neither the name of the Polka Biome Ltd. nor the names of its contributors may be used
+// to endorse or promote products derived from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY Polka Biome Ltd. AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Polka Biome Ltd. BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use crate::*;
 use common::LiquidityProxyTrait;
 use pallet_utility::Call as UtilityCall;

--- a/runtime/src/xor_fee_impls.rs
+++ b/runtime/src/xor_fee_impls.rs
@@ -242,9 +242,6 @@ impl xor_fee::ApplyCustomFees<RuntimeCall, AccountId> for CustomFees {
                     return false;
                 }
             }
-
-            #[cfg(feature = "wip")] // order-book
-            RuntimeCall::OrderBook(order_book::Call::place_limit_order { .. }) => true,
             _ => return false,
         }
     }


### PR DESCRIPTION
Introduce the custom reduced network fee for maket makers.
`place_limit_order` the following network fees:
- reduced fee if the limit order successfully placed
- regular fee if some error occurs
- regular fee if the limit order was converted into a market order