### PR TITLE
Feature/metadata as ci artifact

### DIFF
--- a/.github/workflows/generate_metadata.yml
+++ b/.github/workflows/generate_metadata.yml
@@ -1,0 +1,31 @@
+name: Cargo fmt & clippy
+
+on: [ push ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: arduino/setup-protoc@v2
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate metadata
+        run: cargo build -p substrate-gen
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: my-artifact
+          path: relayer/substrate-gen/src/bytes/metadata.scale
+
+# TODO
+# see https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28
+# curl https://api.github.com/repos/sora-xor/sora2-network/actions/artifacts
+
+# rerun workflow https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-workflow


### PR DESCRIPTION
This PR adds generation of metadata.scale in ci. The file is stored for 90 days and can be accessed with gh api.
See https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28
`curl https://api.github.com/repos/sora-xor/sora2-network/actions/artifacts`
In this JSON the download link can be found by commit hash.