### PR TITLE
Fix weight limit exceeded on swap (attempt 2)

### DIFF
--- a/pallets/order-book/src/weights.rs
+++ b/pallets/order-book/src/weights.rs
@@ -319,9 +319,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Estimated: `154495`
 		// Minimum execution time: 124_000_000 picoseconds.
 		// TODO: benchmark properly, value was set manually
-		Weight::from_parts(50_000_000, 154495)
-			.saturating_add(T::DbWeight::get().reads(13_u64))
-			.saturating_add(T::DbWeight::get().writes(10_u64))
+		Weight::from_parts(0, 0)
 	}
 	/// Storage: OrderBook IncompleteExpirationsSince (r:1 w:0)
 	/// Proof: OrderBook IncompleteExpirationsSince (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -609,9 +607,8 @@ impl WeightInfo for () {
 		//  Measured:  `5123`
 		//  Estimated: `154495`
 		// Minimum execution time: 124_000_000 picoseconds.
-		Weight::from_parts(125_000_000, 154495)
-			.saturating_add(RocksDbWeight::get().reads(13_u64))
-			.saturating_add(RocksDbWeight::get().writes(10_u64))
+		// TODO: benchmark properly, value was set manually
+		Weight::from_parts(0, 0)
 	}
 	/// Storage: OrderBook IncompleteExpirationsSince (r:1 w:0)
 	/// Proof: OrderBook IncompleteExpirationsSince (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1909,8 +1909,9 @@ impl order_book::Config for Runtime {
     const MIN_ORDER_LIFESPAN: Moment = (MINUTES as Moment) * MILLISECS_PER_BLOCK; // 1 minute
     const MILLISECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK;
     const MAX_PRICE_SHIFT: Perbill = Perbill::from_percent(50);
-    const SOFT_MIN_MAX_RATIO: usize = 1000;
-    const HARD_MIN_MAX_RATIO: usize = 4000;
+    // TODO #809: multiply both ratios by 2
+    const SOFT_MIN_MAX_RATIO: usize = 500;
+    const HARD_MIN_MAX_RATIO: usize = 2000;
     type RuntimeEvent = RuntimeEvent;
     type OrderId = u128;
     type Locker = OrderBook;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1909,9 +1909,8 @@ impl order_book::Config for Runtime {
     const MIN_ORDER_LIFESPAN: Moment = (MINUTES as Moment) * MILLISECS_PER_BLOCK; // 1 minute
     const MILLISECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK;
     const MAX_PRICE_SHIFT: Perbill = Perbill::from_percent(50);
-    // TODO #809: multiply both ratios by 3
-    const SOFT_MIN_MAX_RATIO: usize = 1000 / 3;
-    const HARD_MIN_MAX_RATIO: usize = 4000 / 3;
+    const SOFT_MIN_MAX_RATIO: usize = 1000;
+    const HARD_MIN_MAX_RATIO: usize = 4000;
     type RuntimeEvent = RuntimeEvent;
     type OrderId = u128;
     type Locker = OrderBook;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1909,9 +1909,9 @@ impl order_book::Config for Runtime {
     const MIN_ORDER_LIFESPAN: Moment = (MINUTES as Moment) * MILLISECS_PER_BLOCK; // 1 minute
     const MILLISECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK;
     const MAX_PRICE_SHIFT: Perbill = Perbill::from_percent(50);
-    // TODO #809: multiply both ratios by 2
-    const SOFT_MIN_MAX_RATIO: usize = 500;
-    const HARD_MIN_MAX_RATIO: usize = 2000;
+    // TODO #809: multiply both ratios by 3
+    const SOFT_MIN_MAX_RATIO: usize = 1000 / 3;
+    const HARD_MIN_MAX_RATIO: usize = 4000 / 3;
     type RuntimeEvent = RuntimeEvent;
     type OrderId = u128;
     type Locker = OrderBook;


### PR DESCRIPTION
Previous fix only worked for swaps with one inner exchange. This time weight is temporarily set to 0 since maximum 3 exchanges can occur within one swap (for swaps _Synthetic asset -> Basic asset_ and back).