### PR TITLE
Chore/ci buildjet as cache

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,6 +23,9 @@ jobs:
 
       # v2.7.1
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
+        with:
+          # 20GB of cache per repo per week
+          cache-provider: "buildjet"
 
       # v2.20.16
       - name: cargo install


### PR DESCRIPTION
[BuildJet](https://buildjet.com/for-github-actions/docs/about/pricing#build-jet-cache-limits) provides 20GB of cache per repo per week.