### PR TITLE
fix(kensetsu): correct desired output in LiquidityProxy

### DIFF
--- a/pallets/kensetsu/src/lib.rs
+++ b/pallets/kensetsu/src/lib.rs
@@ -1240,7 +1240,9 @@ pub mod pallet {
                 LiquiditySourceFilter::empty(DEXId::Polkaswap.into()),
                 true,
             )?;
-            desired_kusd_amount = desired_kusd_amount.min(amount);
+            // Correct by 1 because LiquidityProxy sometimes requires more max_amount_in with
+            // desired output
+            desired_kusd_amount = desired_kusd_amount.min(amount.saturating_sub(1));
             let treasury_account_id = technical::Pallet::<T>::tech_account_id_to_account_id(
                 &T::TreasuryTechAccount::get(),
             )?;


### PR DESCRIPTION
Steps to reproduce:
```
let to_sell = some_value;
let expected_amount_out = LiquidityProxy::quote(QuoteAmount::WithDesiredInput{desired_amount_in: to_sell}, ...);
LiquidityProxy::exchange(SwapAmount::with_desired_output{expected_amount_out, to_sell}); 
// doesn't work, actually requires to_sell + 0.000000000000001
```
Should work:
```
let to_sell = some_value;
let mut expected_amount_out = LiquidityProxy::quote(QuoteAmount::WithDesiredInput{desired_amount_in: to_sell}, ...);
expected_amount_out = expected_amount_out - 1;
LiquidityProxy::exchange(SwapAmount::with_desired_output{expected_amount_out, to_sell}); 
```