### PR TITLE
Remove git2 dependency and replace its use with simpler solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "framenode-runtime",
- "git2",
  "num-format",
  "pallet-staking",
  "sp-io",
@@ -4345,19 +4344,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "git2"
-version = "0.13.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -5329,18 +5315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.12.26+1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5890,7 +5864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/utils/generate-bags/Cargo.toml
+++ b/utils/generate-bags/Cargo.toml
@@ -15,7 +15,6 @@ frame-election-provider-support = { git = "https://github.com/sora-xor/substrate
 pallet-staking = { git = "https://github.com/sora-xor/substrate.git", branch = "polkadot-v0.9.38" }
 
 chrono = { version = "0.4.19" }
-git2 = { version = "0.13.25", default-features = false }
 num-format = { version = "0.4.0" }
 
 framenode-runtime = { path = "../../runtime", default-features = false, features = [

--- a/utils/generate-bags/src/lib.rs
+++ b/utils/generate-bags/src/lib.rs
@@ -89,7 +89,7 @@ fn existential_weight<T: pallet_staking::Config>(
 /// pretty naive.
 fn path_to_header_file() -> Option<PathBuf> {
     let output = Command::new("git")
-        .args(&["rev-parse", "--show-toplevel"])
+        .args(["rev-parse", "--show-toplevel"])
         .output()
         .expect("Failed to execute git command");
 

--- a/utils/generate-bags/src/lib.rs
+++ b/utils/generate-bags/src/lib.rs
@@ -58,6 +58,7 @@ use frame_election_provider_support::VoteWeight;
 use frame_support::traits::Get;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Compute the existential weight for the specified configuration.
 ///
@@ -87,12 +88,20 @@ fn existential_weight<T: pallet_staking::Config>(
 /// Just searches the git working directory root for files matching certain patterns; it's
 /// pretty naive.
 fn path_to_header_file() -> Option<PathBuf> {
-    let repo = git2::Repository::open_from_env().ok()?;
-    let workdir = repo.workdir()?;
-    for file_name in &["HEADER-APACHE2", "HEADER-GPL3", "HEADER", "file_header.txt"] {
-        let path = workdir.join(file_name);
-        if path.exists() {
-            return Some(path);
+    let output = Command::new("git")
+        .args(&["rev-parse", "--show-toplevel"])
+        .output()
+        .expect("Failed to execute git command");
+
+    if output.status.success() {
+        let stdout = std::str::from_utf8(&output.stdout).expect("Invalid UTF-8");
+        let workdir = Path::new(stdout.trim());
+
+        for file_name in &["HEADER-APACHE2", "HEADER-GPL3", "HEADER", "file_header.txt"] {
+            let path = workdir.join(file_name);
+            if path.exists() {
+                return Some(path);
+            }
         }
     }
     None


### PR DESCRIPTION
- Removed git2 dependency and used Command to get workdir of the repo instead of using git2 module