### PR TITLE
Fix Apollo liquidation logic

### DIFF
--- a/pallets/apollo-platform/src/benchmarking.rs
+++ b/pallets/apollo-platform/src/benchmarking.rs
@@ -362,7 +362,7 @@ benchmarks! {
             borrow_amount
         ).unwrap()
     } verify {
-        assert_last_event::<T>(Event::Borrowed(alice, DOT.into(),collateral_amount , XOR.into(), borrow_amount).into());
+        assert_last_event::<T>(Event::Borrowed(alice, DOT.into(), collateral_amount, XOR.into(), borrow_amount).into());
     }
 
     get_rewards {
@@ -740,7 +740,6 @@ benchmarks! {
             edit_parameter_value,
             edit_parameter_value,
             edit_parameter_value,
-
         ).unwrap()
     }
     verify {

--- a/pallets/apollo-platform/src/benchmarking.rs
+++ b/pallets/apollo-platform/src/benchmarking.rs
@@ -277,7 +277,7 @@ benchmarks! {
             lending_amount
         ).unwrap()
     } verify {
-        assert_last_event::<T>(Event::Lended(alice, asset_id.into(), lending_amount).into());
+        assert_last_event::<T>(Event::Lent(alice, asset_id.into(), lending_amount).into());
     }
 
     borrow {

--- a/pallets/apollo-platform/src/lib.rs
+++ b/pallets/apollo-platform/src/lib.rs
@@ -1019,8 +1019,8 @@ pub mod pallet {
                     DEXId::Polkaswap.into(),
                     &Self::account_id(),
                     &Self::account_id(),
-                    &(*collateral_asset),
-                    &asset_id.into(),
+                    collateral_asset,
+                    &asset_id,
                     SwapAmount::with_desired_input(amount_to_exchange, Balance::zero()),
                     LiquiditySourceFilter::empty(DEXId::Polkaswap.into()),
                 )?;
@@ -1043,7 +1043,7 @@ pub mod pallet {
             let mut borrow_pool_info = PoolData::<T>::get(asset_id).unwrap_or_default();
             borrow_pool_info.total_borrowed = borrow_pool_info
                 .total_borrowed
-                .saturating_sub(total_borrowed.clone());
+                .saturating_sub(total_borrowed);
 
             <PoolData<T>>::insert(asset_id, borrow_pool_info);
             <UserBorrowingInfo<T>>::remove(asset_id, user.clone());

--- a/pallets/apollo-platform/src/mock.rs
+++ b/pallets/apollo-platform/src/mock.rs
@@ -455,13 +455,22 @@ impl LiquidityProxyTrait<DEXId, AccountId, AssetId> for MockLiquidityProxy {
             amount.amount(),
         );
 
-        // Transfer from exchange account (output asset)
-        let _ = Assets::transfer(
-            RawOrigin::Signed(exchange_account()).into(),
-            *output_asset_id,
-            receiver.clone(),
-            amount.amount(),
-        );
+        if input_asset_id == &DAI && output_asset_id != &APOLLO_ASSET_ID {
+            let _ = Assets::transfer(
+                RawOrigin::Signed(exchange_account()).into(),
+                *output_asset_id,
+                receiver.clone(),
+                amount.amount() * balance!(0.1) / balance!(1),
+            );
+        } else {
+            // Transfer from exchange account (output asset)
+            let _ = Assets::transfer(
+                RawOrigin::Signed(exchange_account()).into(),
+                *output_asset_id,
+                receiver.clone(),
+                amount.amount(),
+            );
+        }
 
         Ok(SwapOutcome::new(amount.amount(), Default::default()))
     }

--- a/pallets/apollo-platform/src/tests.rs
+++ b/pallets/apollo-platform/src/tests.rs
@@ -828,7 +828,7 @@ mod test {
     }
 
     #[test]
-    fn borrow_nothing_lended() {
+    fn borrow_nothing_lent() {
         let mut ext = ExtBuilder::default().build();
         ext.execute_with(|| {
             assert_ok!(assets::Pallet::<Runtime>::mint_to(
@@ -872,7 +872,7 @@ mod test {
 
             assert_err!(
                 ApolloPlatform::borrow(RuntimeOrigin::signed(alice()), DOT, XOR, balance!(100)),
-                Error::<Runtime>::NothingLended
+                Error::<Runtime>::NothingLent
             );
         });
     }
@@ -1258,7 +1258,7 @@ mod test {
     }
 
     #[test]
-    fn get_lending_rewards_nothing_lended() {
+    fn get_lending_rewards_nothing_lent() {
         let mut ext = ExtBuilder::default().build();
         ext.execute_with(|| {
             assert_ok!(ApolloPlatform::add_pool(
@@ -1275,7 +1275,7 @@ mod test {
 
             assert_err!(
                 ApolloPlatform::get_rewards(RuntimeOrigin::signed(alice()), XOR, true),
-                Error::<Runtime>::NothingLended
+                Error::<Runtime>::NothingLent
             );
         });
     }
@@ -1855,7 +1855,7 @@ mod test {
     }
 
     #[test]
-    fn withdraw_nothing_lended() {
+    fn withdraw_nothing_lent() {
         let mut ext = ExtBuilder::default().build();
         ext.execute_with(|| {
             assert_ok!(ApolloPlatform::add_pool(
@@ -1872,7 +1872,7 @@ mod test {
 
             assert_err!(
                 ApolloPlatform::withdraw(RuntimeOrigin::signed(alice()), XOR, balance!(100)),
-                Error::<Runtime>::NothingLended
+                Error::<Runtime>::NothingLent
             );
         });
     }
@@ -2457,27 +2457,27 @@ mod test {
 
             let borrowing_interest_one_more_block =
                 calculate_borrowing_interest(alice(), XOR, DOT, 150);
-            let repayed_amount = borrowing_interest_one_more_block.0;
+            let repaid_amount = borrowing_interest_one_more_block.0;
 
             // Reserve amounts (treasury, burn, developer)
             let (treasury_reserve, _, developer_reserve) =
-                calculate_reserve_amounts(XOR, repayed_amount);
+                calculate_reserve_amounts(XOR, repaid_amount);
 
             assert_ok!(ApolloPlatform::repay(
                 RuntimeOrigin::signed(alice()),
                 DOT,
                 XOR,
-                repayed_amount
+                repaid_amount
             ));
 
             // Check borrowing asset pool values after repay
             let borrowing_asset_pool_info = pallet::PoolData::<Runtime>::get(XOR).unwrap();
 
             let reserves_amount = (FixedWrapper::from(borrowing_asset_pool_info.reserve_factor)
-                * FixedWrapper::from(repayed_amount))
+                * FixedWrapper::from(repaid_amount))
             .try_into_balance()
             .unwrap_or(0);
-            let rewards_amount = repayed_amount - reserves_amount;
+            let rewards_amount = repaid_amount - reserves_amount;
 
             assert_eq!(borrowing_asset_pool_info.rewards, rewards_amount);
             assert_eq!(borrowing_asset_pool_info.total_borrowed, balance!(200));
@@ -2488,7 +2488,7 @@ mod test {
             let borrowing_user_debt = borrow_user_info.get(&DOT).unwrap();
             let borrowing_interest = borrowing_user_debt.borrowing_interest;
 
-            let new_alice_balance = balance!(200) - repayed_amount;
+            let new_alice_balance = balance!(200) - repaid_amount;
 
             assert_eq!(borrowing_interest, balance!(0));
 
@@ -2634,7 +2634,7 @@ mod test {
 
             let borrowing_interest_one_more_block =
                 calculate_borrowing_interest(alice(), XOR, DOT, 150);
-            let repayed_amount = borrowing_interest_one_more_block.0 + balance!(1);
+            let repaid_amount = borrowing_interest_one_more_block.0 + balance!(1);
 
             // Reserve amounts (treasury, burn, developer)
             let (treasury_reserve, _, developer_reserve) =
@@ -2644,14 +2644,14 @@ mod test {
                 RuntimeOrigin::signed(alice()),
                 DOT,
                 XOR,
-                repayed_amount
+                repaid_amount
             ));
 
             let borrow_user_info = pallet::UserBorrowingInfo::<Runtime>::get(XOR, alice()).unwrap();
             let borrowing_user_debt = borrow_user_info.get(&DOT).unwrap();
             let borrowing_interest = borrowing_user_debt.borrowing_interest;
 
-            let new_alice_balance = balance!(200) - repayed_amount;
+            let new_alice_balance = balance!(200) - repaid_amount;
 
             // Check Alice position values after repay
             assert_eq!(borrowing_user_debt.borrowing_amount, balance!(199));
@@ -2828,7 +2828,7 @@ mod test {
 
             let borrowing_interest_one_more_block =
                 calculate_borrowing_interest(alice(), XOR, DOT, 150);
-            let repayed_amount = borrowing_interest_one_more_block.0 + balance!(200);
+            let repaid_amount = borrowing_interest_one_more_block.0 + balance!(200);
 
             // Reserve amounts (treasury, burn, developer)
             let (treasury_reserve, _, developer_reserve) =
@@ -2838,7 +2838,7 @@ mod test {
                 RuntimeOrigin::signed(alice()),
                 DOT,
                 XOR,
-                repayed_amount
+                repaid_amount
             ));
 
             // Check borrowing asset pool values after repay
@@ -2858,7 +2858,7 @@ mod test {
 
             let borrow_user_info = pallet::UserBorrowingInfo::<Runtime>::get(XOR, alice());
 
-            let new_alice_balance = balance!(300) - repayed_amount;
+            let new_alice_balance = balance!(300) - repaid_amount;
 
             // Check if Alice's position exists after repay
             assert_eq!(borrow_user_info, None);
@@ -4116,7 +4116,7 @@ mod test {
 
             assert_eq!(
                 borrowing_asset_pool_info_after_lq.total_liquidity,
-                borrowing_pool_before_lq.total_liquidity
+                borrowing_pool_before_lq.total_liquidity + borrowing_pool_before_lq.total_borrowed
             );
 
             assert_eq!(
@@ -4354,7 +4354,7 @@ mod test {
 
             assert_eq!(
                 borrowing_asset_pool_info_after_lq.total_liquidity,
-                borrowing_pool_before_lq.total_liquidity
+                borrowing_pool_before_lq.total_liquidity + borrowing_pool_before_lq.total_borrowed
             );
 
             assert_eq!(

--- a/pallets/apollo-platform/src/tests.rs
+++ b/pallets/apollo-platform/src/tests.rs
@@ -4517,7 +4517,7 @@ mod test {
 
             assert_ok!(ApolloPlatform::add_pool(
                 user.clone(),
-                asset_id.clone(),
+                asset_id,
                 initial_parameter_value,
                 initial_parameter_value,
                 initial_parameter_value,
@@ -4527,11 +4527,11 @@ mod test {
                 initial_parameter_value,
             ));
 
-            let pool_info_before_edit = pallet::PoolData::<Runtime>::get(asset_id.clone()).unwrap();
+            let pool_info_before_edit = pallet::PoolData::<Runtime>::get(asset_id).unwrap();
 
             assert_ok!(ApolloPlatform::edit_pool_info(
-                user.clone(),
-                asset_id.clone(),
+                user,
+                asset_id,
                 edit_parameter_value,
                 edit_parameter_value,
                 edit_parameter_value,
@@ -4541,7 +4541,7 @@ mod test {
                 edit_parameter_value,
             ));
 
-            let pool_info_after_edit = pallet::PoolData::<Runtime>::get(asset_id.clone()).unwrap();
+            let pool_info_after_edit = pallet::PoolData::<Runtime>::get(asset_id).unwrap();
 
             // Asserting pool info basic lending rate not changed
             assert_eq!(
@@ -4565,7 +4565,6 @@ mod test {
             assert_eq!(pool_info_after_edit.slope_rate_1, edit_parameter_value);
             assert_eq!(pool_info_after_edit.slope_rate_2, edit_parameter_value);
             assert_eq!(pool_info_after_edit.reserve_factor, edit_parameter_value);
-            assert_eq!(pool_info_after_edit.is_removed, false);
         });
     }
 
@@ -4579,8 +4578,8 @@ mod test {
             let edit_parameter_value = balance!(0.8);
 
             assert_ok!(ApolloPlatform::add_pool(
-                user.clone(),
-                asset_id.clone(),
+                user,
+                asset_id,
                 initial_parameter_value,
                 initial_parameter_value,
                 initial_parameter_value,
@@ -4593,7 +4592,7 @@ mod test {
             assert_err!(
                 ApolloPlatform::edit_pool_info(
                     RuntimeOrigin::signed(alice()),
-                    asset_id.clone(),
+                    asset_id,
                     edit_parameter_value,
                     edit_parameter_value,
                     edit_parameter_value,

--- a/pallets/apollo-platform/src/tests.rs
+++ b/pallets/apollo-platform/src/tests.rs
@@ -4505,4 +4505,105 @@ mod test {
             }
         });
     }
+
+    #[test]
+    fn edit_pool_info_ok() {
+        let mut ext = ExtBuilder::default().build();
+        ext.execute_with(|| {
+            let user = RuntimeOrigin::signed(ApolloPlatform::authority_account());
+            let asset_id = XOR;
+            let initial_parameter_value = balance!(1);
+            let edit_parameter_value = balance!(0.8);
+
+            assert_ok!(ApolloPlatform::add_pool(
+                user.clone(),
+                asset_id.clone(),
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+            ));
+
+            let pool_info_before_edit = pallet::PoolData::<Runtime>::get(asset_id.clone()).unwrap();
+
+            assert_ok!(ApolloPlatform::edit_pool_info(
+                user.clone(),
+                asset_id.clone(),
+                edit_parameter_value,
+                edit_parameter_value,
+                edit_parameter_value,
+                edit_parameter_value,
+                edit_parameter_value,
+                edit_parameter_value,
+                edit_parameter_value,
+            ));
+
+            let pool_info_after_edit = pallet::PoolData::<Runtime>::get(asset_id.clone()).unwrap();
+
+            // Asserting pool info basic lending rate not changed
+            assert_eq!(
+                pool_info_before_edit.basic_lending_rate,
+                pool_info_after_edit.basic_lending_rate
+            );
+
+            // Asserting pool info borrowing rewards rate not changed
+            assert_eq!(
+                pool_info_before_edit.borrowing_rewards_rate,
+                pool_info_after_edit.borrowing_rewards_rate
+            );
+
+            // Asserting pool info parameters are changed
+            assert_eq!(pool_info_after_edit.loan_to_value, edit_parameter_value);
+            assert_eq!(
+                pool_info_after_edit.optimal_utilization_rate,
+                edit_parameter_value
+            );
+            assert_eq!(pool_info_after_edit.base_rate, edit_parameter_value);
+            assert_eq!(pool_info_after_edit.slope_rate_1, edit_parameter_value);
+            assert_eq!(pool_info_after_edit.slope_rate_2, edit_parameter_value);
+            assert_eq!(pool_info_after_edit.reserve_factor, edit_parameter_value);
+            assert_eq!(pool_info_after_edit.is_removed, false);
+        });
+    }
+
+    #[test]
+    fn edit_pool_info_unauthorized() {
+        let mut ext = ExtBuilder::default().build();
+        ext.execute_with(|| {
+            let user = RuntimeOrigin::signed(ApolloPlatform::authority_account());
+            let asset_id = XOR;
+            let initial_parameter_value = balance!(1);
+            let edit_parameter_value = balance!(0.8);
+
+            assert_ok!(ApolloPlatform::add_pool(
+                user.clone(),
+                asset_id.clone(),
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+                initial_parameter_value,
+            ));
+
+            assert_err!(
+                ApolloPlatform::edit_pool_info(
+                    RuntimeOrigin::signed(alice()),
+                    asset_id.clone(),
+                    edit_parameter_value,
+                    edit_parameter_value,
+                    edit_parameter_value,
+                    edit_parameter_value,
+                    edit_parameter_value,
+                    edit_parameter_value,
+                    edit_parameter_value,
+                ),
+                Error::<Runtime>::Unauthorized
+            );
+        });
+    }
 }

--- a/pallets/apollo-platform/src/weights.rs
+++ b/pallets/apollo-platform/src/weights.rs
@@ -44,6 +44,7 @@ pub trait WeightInfo {
 	fn change_rewards_per_block() -> Weight;
 	fn liquidate() -> Weight;
 	fn remove_pool() -> Weight;
+	fn edit_pool_info() -> Weight;
 }
 
 /// Weight functions for `apollo_platform`.
@@ -275,6 +276,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	/// Storage: ApolloPlatform AuthorityAccount (r:1 w:0)
+	/// Proof Skipped: ApolloPlatform AuthorityAccount (max_values: Some(1), max_size: None, mode: Measured)
+	/// Storage: ApolloPlatform PoolData (r:1 w:1)
+	/// Proof Skipped: ApolloPlatform PoolData (max_values: None, max_size: None, mode: Measured)
+	fn edit_pool_info() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `481`
+		//  Estimated: `3932`
+		// Minimum execution time: 8_660 nanoseconds.
+		Weight::from_parts(10_127_000, 3932)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
 }
 
 // For backwards compatibility and tests
@@ -503,6 +517,19 @@ impl WeightInfo for () {
 		// Minimum execution time: 69_823 nanoseconds.
 		Weight::from_parts(74_262_000, 8371)
 			.saturating_add(RocksDbWeight::get().reads(5))
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+	/// Storage: ApolloPlatform AuthorityAccount (r:1 w:0)
+	/// Proof Skipped: ApolloPlatform AuthorityAccount (max_values: Some(1), max_size: None, mode: Measured)
+	/// Storage: ApolloPlatform PoolData (r:1 w:1)
+	/// Proof Skipped: ApolloPlatform PoolData (max_values: None, max_size: None, mode: Measured)
+	fn edit_pool_info() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `481`
+		//  Estimated: `3932`
+		// Minimum execution time: 8_660 nanoseconds.
+		Weight::from_parts(10_127_000, 3932)
+			.saturating_add(RocksDbWeight::get().reads(2))
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 }


### PR DESCRIPTION
- Fixed Apollo liquidation logic
- Fixed lend benchmark and removed Apollo asset registering from setup_benchmark, instead minting it with apollo_owner account
- Added new extrinsic for editing pool info along with tests and benchmark