### PR TITLE
Fix release 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "framenode"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "ahash 0.8.5",
  "ansi_term",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "framenode-chain-spec"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "common",
  "faucet",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "framenode-runtime"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "apollo-platform",
  "assets",


### PR DESCRIPTION
Update the forgotten `Cargo.lock`.
Related to #1036 