### PR TITLE
Order Book: quote limits

### DIFF
--- a/node/chain_spec/src/lib.rs
+++ b/node/chain_spec/src/lib.rs
@@ -2146,6 +2146,7 @@ fn mainnet_genesis(
         )
     }));
     GenesisConfig {
+        #[cfg(feature = "wip")] // EVM bridge
         evm_fungible_app: Default::default(),
         parachain_bridge_app: Default::default(),
         substrate_bridge_outbound_channel: Default::default(),

--- a/pallets/order-book/src/tests/pallet.rs
+++ b/pallets/order-book/src/tests/pallet.rs
@@ -1340,6 +1340,367 @@ fn should_not_quote_with_small_amount() {
 }
 
 #[test]
+fn should_not_quote_with_wrong_order_amount() {
+    ext().execute_with(|| {
+        let order_book_id = OrderBookId::<AssetIdOf<Runtime>, DEXId> {
+            dex_id: DEX.into(),
+            base: VAL,
+            quote: XOR,
+        };
+
+        let base_min_amount = balance!(5);
+        let base_max_amount = balance!(100);
+
+        // values are calculated based on the orders in `create_and_fill_order_book`
+        let quote_buy_min_amount = balance!(55);
+        let quote_buy_max_amount = balance!(1100);
+        let quote_sell_min_amount = balance!(50);
+        let quote_sell_max_amount = balance!(1000);
+
+        let order_book = create_and_fill_order_book::<Runtime>(order_book_id);
+        let step_lot_size = *order_book.step_lot_size.balance();
+        let _ = update_orderbook_unchecked::<Runtime>(
+            order_book_id,
+            *order_book.tick_size.balance(),
+            step_lot_size,
+            base_min_amount,
+            base_max_amount,
+        );
+
+        // XOR -> VAL: less than min amount
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_input(quote_buy_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_input(quote_buy_min_amount - balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::new(),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Input(quote_buy_min_amount)),
+                    Some(SideAmount::Input(quote_buy_max_amount)),
+                    Some(SideAmount::Output(step_lot_size))
+                )
+            }
+        );
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_output(base_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_output(base_min_amount - balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::new(),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Output(base_min_amount)),
+                    Some(SideAmount::Output(base_max_amount)),
+                    Some(SideAmount::Output(step_lot_size))
+                )
+            }
+        );
+
+        // XOR -> VAL: more than max amount
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_input(quote_buy_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_input(quote_buy_max_amount + balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::from([SwapChunk::new(
+                    balance!(1939.3),
+                    balance!(176.3),
+                    Default::default()
+                )]),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Input(quote_buy_min_amount)),
+                    Some(SideAmount::Input(quote_buy_max_amount)),
+                    Some(SideAmount::Output(step_lot_size))
+                )
+            }
+        );
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_output(base_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_output(base_max_amount + balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::from([SwapChunk::new(
+                    balance!(1939.3),
+                    balance!(176.3),
+                    Default::default()
+                )]),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Output(base_min_amount)),
+                    Some(SideAmount::Output(base_max_amount)),
+                    Some(SideAmount::Output(step_lot_size))
+                )
+            }
+        );
+
+        // VAL -> XOR: less than min amount
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_input(base_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_input(base_min_amount - balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::new(),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Input(base_min_amount)),
+                    Some(SideAmount::Input(base_max_amount)),
+                    Some(SideAmount::Input(step_lot_size))
+                )
+            }
+        );
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_output(quote_sell_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_output(quote_sell_min_amount - balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::new(),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Output(quote_sell_min_amount)),
+                    Some(SideAmount::Output(quote_sell_max_amount)),
+                    Some(SideAmount::Input(step_lot_size))
+                )
+            }
+        );
+
+        // VAL -> XOR: more than max amount
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_input(base_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_input(base_max_amount + balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::from([SwapChunk::new(
+                    balance!(168.5),
+                    balance!(1685),
+                    Default::default()
+                )]),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Input(base_min_amount)),
+                    Some(SideAmount::Input(base_max_amount)),
+                    Some(SideAmount::Input(step_lot_size))
+                )
+            }
+        );
+
+        assert_err!(
+            OrderBookPallet::quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_output(quote_sell_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_eq!(
+            OrderBookPallet::step_quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_output(quote_sell_max_amount + balance!(1)),
+                10,
+                true
+            )
+            .unwrap()
+            .0,
+            DiscreteQuotation {
+                chunks: VecDeque::from([SwapChunk::new(
+                    balance!(168.5),
+                    balance!(1685),
+                    Default::default()
+                )]),
+                limits: SwapLimits::new(
+                    Some(SideAmount::Output(quote_sell_min_amount)),
+                    Some(SideAmount::Output(quote_sell_max_amount)),
+                    Some(SideAmount::Input(step_lot_size))
+                )
+            }
+        );
+
+        // ok if values are equal with min/max
+
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_input(quote_buy_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_input(quote_buy_max_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_output(base_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_output(base_max_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_input(base_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_input(base_max_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_output(quote_sell_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_output(quote_sell_max_amount),
+            true
+        ));
+    });
+}
+
+#[test]
 fn should_not_quote_if_amount_is_greater_than_liquidity() {
     ext().execute_with(|| {
         let order_book_id = OrderBookId::<AssetIdOf<Runtime>, DEXId> {

--- a/pallets/order-book/src/tests/pallet.rs
+++ b/pallets/order-book/src/tests/pallet.rs
@@ -1379,6 +1379,16 @@ fn should_not_quote_with_wrong_order_amount() {
             ),
             E::InvalidOrderAmount
         );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_input(quote_buy_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
         assert_eq!(
             OrderBookPallet::step_quote(
                 &DEX.into(),
@@ -1402,6 +1412,16 @@ fn should_not_quote_with_wrong_order_amount() {
 
         assert_err!(
             OrderBookPallet::quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_output(base_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
                 &DEX.into(),
                 &XOR,
                 &VAL,
@@ -1443,6 +1463,16 @@ fn should_not_quote_with_wrong_order_amount() {
             ),
             E::InvalidOrderAmount
         );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_input(quote_buy_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
         assert_eq!(
             OrderBookPallet::step_quote(
                 &DEX.into(),
@@ -1470,6 +1500,16 @@ fn should_not_quote_with_wrong_order_amount() {
 
         assert_err!(
             OrderBookPallet::quote(
+                &DEX.into(),
+                &XOR,
+                &VAL,
+                QuoteAmount::with_desired_output(base_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
                 &DEX.into(),
                 &XOR,
                 &VAL,
@@ -1515,6 +1555,16 @@ fn should_not_quote_with_wrong_order_amount() {
             ),
             E::InvalidOrderAmount
         );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_input(base_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
         assert_eq!(
             OrderBookPallet::step_quote(
                 &DEX.into(),
@@ -1538,6 +1588,16 @@ fn should_not_quote_with_wrong_order_amount() {
 
         assert_err!(
             OrderBookPallet::quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_output(quote_sell_min_amount - balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
                 &DEX.into(),
                 &VAL,
                 &XOR,
@@ -1579,6 +1639,16 @@ fn should_not_quote_with_wrong_order_amount() {
             ),
             E::InvalidOrderAmount
         );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_input(base_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
         assert_eq!(
             OrderBookPallet::step_quote(
                 &DEX.into(),
@@ -1606,6 +1676,16 @@ fn should_not_quote_with_wrong_order_amount() {
 
         assert_err!(
             OrderBookPallet::quote(
+                &DEX.into(),
+                &VAL,
+                &XOR,
+                QuoteAmount::with_desired_output(quote_sell_max_amount + balance!(1)),
+                true
+            ),
+            E::InvalidOrderAmount
+        );
+        assert_err!(
+            OrderBookPallet::quote_without_impact(
                 &DEX.into(),
                 &VAL,
                 &XOR,
@@ -1691,6 +1771,63 @@ fn should_not_quote_with_wrong_order_amount() {
             true
         ));
         assert_ok!(OrderBookPallet::quote(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_output(quote_sell_max_amount),
+            true
+        ));
+
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_input(quote_buy_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_input(quote_buy_max_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_output(base_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &XOR,
+            &VAL,
+            QuoteAmount::with_desired_output(base_max_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_input(base_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_input(base_max_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
+            &DEX.into(),
+            &VAL,
+            &XOR,
+            QuoteAmount::with_desired_output(quote_sell_min_amount),
+            true
+        ));
+        assert_ok!(OrderBookPallet::quote_without_impact(
             &DEX.into(),
             &VAL,
             &XOR,


### PR DESCRIPTION
`quote` & `quote_without_impact` return error if the amount doesn't match the min/max values.

`step_quote` returns empty chunks and actual limits if the amount is lower than min value and it returns chunks are limited by max value if the amount is higher than max value.