### PR TITLE
fix(kensetsu): fix CollateralInfos migration

### DIFF
--- a/pallets/kensetsu/src/migrations.rs
+++ b/pallets/kensetsu/src/migrations.rs
@@ -268,16 +268,21 @@ pub mod v1_to_v2 {
                 );
                 weight += <T as frame_system::Config>::DbWeight::get().writes(1);
 
-                for (collateral_asset_id, old_collateral_info) in v1::CollateralInfos::<T>::drain()
-                {
-                    CollateralInfos::<T>::insert(
-                        StablecoinCollateralIdentifier {
-                            collateral_asset_id,
-                            stablecoin_asset_id: AssetIdOf::<T>::from(KUSD),
-                        },
-                        old_collateral_info.into_v2(),
-                    );
-                    weight += <T as frame_system::Config>::DbWeight::get().writes(1);
+                let collateral_infos: Vec<_> = v1::CollateralInfos::<T>::drain()
+                    .map(|(collateral_asset_id, old_collateral_info)| {
+                        weight += <T as frame_system::Config>::DbWeight::get().writes(1);
+
+                        (
+                            StablecoinCollateralIdentifier {
+                                collateral_asset_id,
+                                stablecoin_asset_id: AssetIdOf::<T>::from(KUSD),
+                            },
+                            old_collateral_info.into_v2(),
+                        )
+                    })
+                    .collect();
+                for (stablecoin_identifier, collateral_info) in collateral_infos {
+                    CollateralInfos::<T>::insert(stablecoin_identifier, collateral_info);
                 }
 
                 v1::CDPDepository::<T>::translate(


### PR DESCRIPTION
This fixes double reading of CollateralInfos. Despite of defining old `v1::CollateralInfos` and new `CollateralInfos` they are essentially the same storage, so inserting after `drain` results in UB, which is double reading of values. In this particular case it doesn't break the logic, but for general purpose the storage must be drained completely before the inserting updated values.