### PR TITLE
1112/add storage to store regulated-assets for SBT

### DIFF
--- a/pallets/extended-assets/src/lib.rs
+++ b/pallets/extended-assets/src/lib.rs
@@ -55,6 +55,8 @@ use common::{
     BalancePrecision, ContentSource, Description, IsValid,
 };
 use frame_support::sp_runtime::DispatchError;
+use frame_support::BoundedBTreeSet;
+use sp_core::Get;
 use weights::WeightInfo;
 
 type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -63,11 +65,14 @@ type Timestamp<T> = pallet_timestamp::Pallet<T>;
 pub use pallet::*;
 
 #[derive(Clone, Eq, Encode, Decode, scale_info::TypeInfo, PartialEq, MaxEncodedLen)]
-pub struct SoulboundTokenMetadata<Moment> {
+#[scale_info(skip_type_params(MaxRegulatedAssetsPerSBT))]
+pub struct SoulboundTokenMetadata<Moment, AssetId, MaxRegulatedAssetsPerSBT: Get<u32>> {
     /// External link of issued place
     external_url: Option<ContentSource>,
     /// Issuance Timestamp
     issued_at: Moment,
+    /// List of regulated assets permissioned by this token
+    regulated_assets: BoundedBTreeSet<AssetId, MaxRegulatedAssetsPerSBT>,
 }
 
 #[frame_support::pallet]
@@ -94,6 +99,10 @@ pub mod pallet {
             ContentSource,
             Description,
         >;
+
+        /// Max number of regulated assets per one Soulbound Token
+        #[pallet::constant]
+        type MaxRegulatedAssetsPerSBT: Get<u32>;
 
         /// Weight information for extrinsics in this pallet
         type WeightInfo: WeightInfo;
@@ -185,6 +194,7 @@ pub mod pallet {
             let metadata = SoulboundTokenMetadata {
                 external_url: external_url.clone(),
                 issued_at: now_timestamp,
+                regulated_assets: Default::default(),
             };
 
             <SoulboundAsset<T>>::insert(sbt_asset_id, metadata);
@@ -274,7 +284,27 @@ pub mod pallet {
 
             Self::check_regulated_assets_for_binding(&regulated_asset_id, &who)?;
 
+            // In case the regulated asset is already bound to another SBT, we need to unbind it
+            // by removing it from the previous SBT's regulated assets list.
+            if <RegulatedAssetToSoulboundAsset<T>>::contains_key(regulated_asset_id) {
+                let previous_sbt = Self::regulated_asset_to_sbt(regulated_asset_id);
+                <SoulboundAsset<T>>::mutate(previous_sbt, |metadata| {
+                    if let Some(metadata) = metadata {
+                        metadata.regulated_assets.remove(&regulated_asset_id);
+                    }
+                });
+            }
+
+            // Bind the regulated asset to the SBT and update the SBT's metadata
             <RegulatedAssetToSoulboundAsset<T>>::set(regulated_asset_id, sbt_asset_id);
+            <SoulboundAsset<T>>::mutate(sbt_asset_id, |metadata| {
+                if let Some(metadata) = metadata {
+                    metadata
+                        .regulated_assets
+                        .try_insert(regulated_asset_id)
+                        .ok();
+                }
+            });
 
             Self::deposit_event(Event::RegulatedAssetBoundToSBT {
                 regulated_asset_id,
@@ -351,8 +381,13 @@ pub mod pallet {
     /// Mapping from SBT (asset_id) to its metadata
     #[pallet::storage]
     #[pallet::getter(fn soulbound_asset)]
-    pub type SoulboundAsset<T: Config> =
-        StorageMap<_, Identity, AssetIdOf<T>, SoulboundTokenMetadata<T::Moment>, OptionQuery>;
+    pub type SoulboundAsset<T: Config> = StorageMap<
+        _,
+        Identity,
+        AssetIdOf<T>,
+        SoulboundTokenMetadata<T::Moment, AssetIdOf<T>, T::MaxRegulatedAssetsPerSBT>,
+        OptionQuery,
+    >;
 
     /// Mapping from Regulated asset id to SBT asset id
     #[pallet::storage]

--- a/pallets/extended-assets/src/mock.rs
+++ b/pallets/extended-assets/src/mock.rs
@@ -40,7 +40,7 @@ use currencies::BasicCurrencyAdapter;
 use frame_support::traits::Everything;
 use frame_support::{construct_runtime, parameter_types};
 use hex_literal::hex;
-use sp_core::H256;
+use sp_core::{ConstU32, H256};
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
@@ -99,9 +99,12 @@ impl assets::Config for TestRuntime {
     );
 }
 
+pub type MockMaxRegulatedAssetsPerSBT = ConstU32<10000>;
+
 impl extended_assets::Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
     type AssetInfoProvider = assets::Pallet<TestRuntime>;
+    type MaxRegulatedAssetsPerSBT = MockMaxRegulatedAssetsPerSBT;
     type WeightInfo = ();
 }
 

--- a/pallets/extended-assets/src/weights.rs
+++ b/pallets/extended-assets/src/weights.rs
@@ -125,22 +125,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	/// Storage: ExtendedAssets SoulboundAsset (r:1 w:0)
-	/// Proof: ExtendedAssets SoulboundAsset (max_values: None, max_size: Some(2089), added: 4564, mode: MaxEncodedLen)
+	/// Storage: ExtendedAssets SoulboundAsset (r:1 w:1)
+	/// Proof: ExtendedAssets SoulboundAsset (max_values: None, max_size: Some(322091), added: 324566, mode: MaxEncodedLen)
 	/// Storage: Assets AssetOwners (r:2 w:0)
 	/// Proof Skipped: Assets AssetOwners (max_values: None, max_size: None, mode: Measured)
 	/// Storage: ExtendedAssets RegulatedAsset (r:1 w:0)
 	/// Proof: ExtendedAssets RegulatedAsset (max_values: None, max_size: Some(33), added: 2508, mode: MaxEncodedLen)
-	/// Storage: ExtendedAssets RegulatedAssetToSoulboundAsset (r:0 w:1)
+	/// Storage: ExtendedAssets RegulatedAssetToSoulboundAsset (r:1 w:1)
 	/// Proof: ExtendedAssets RegulatedAssetToSoulboundAsset (max_values: None, max_size: Some(64), added: 2539, mode: MaxEncodedLen)
 	fn bind_regulated_asset_to_sbt() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1030`
-		//  Estimated: `13052`
-		// Minimum execution time: 23_000 nanoseconds.
-		Weight::from_parts(24_000_000, 13052)
-			.saturating_add(T::DbWeight::get().reads(4))
-			.saturating_add(T::DbWeight::get().writes(1))
+		//  Measured:  `1031`
+		//  Estimated: `335594`
+		// Minimum execution time: 27_000 nanoseconds.
+		Weight::from_parts(28_000_000, 335594)
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(2))
 	}
 }
 
@@ -166,9 +166,9 @@ impl WeightInfo for () {
 	}
 	
 	fn bind_regulated_asset_to_sbt() -> Weight {
-			Weight::from_parts(23_000_000, 13052)
-			.saturating_add(RocksDbWeight::get().reads(4))
-			.saturating_add(RocksDbWeight::get().writes(1))
+			Weight::from_parts(28_000_000, 335594)
+			.saturating_add(RocksDbWeight::get().reads(5))
+			.saturating_add(RocksDbWeight::get().writes(2))
 		}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2427,6 +2427,7 @@ impl multisig_verifier::Config for Runtime {
 impl extended_assets::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type AssetInfoProvider = Assets;
+    type MaxRegulatedAssetsPerSBT = ConstU32<10000>;
     type WeightInfo = extended_assets::weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
## Changes

- Added `regulated_assets` as `BTreeSet` to `SoulboundTokenMetadata`
- Manage this set when binding regulated asset to SBT in `bind_regulated_asset_to_sbt` extrinsic
- Added unit test for testing the logic
- Ran benchmarks and updated the weights 