### PR TITLE
1135/DeFi-R. User Flow optimization

### DIFF
--- a/pallets/extended-assets/src/benchmarking.rs
+++ b/pallets/extended-assets/src/benchmarking.rs
@@ -63,6 +63,7 @@ benchmarks! {
         let owner = asset_owner::<T>();
         let owner_origin: <T as frame_system::Config>::RuntimeOrigin = RawOrigin::Signed(owner.clone()).into();
         frame_system::Pallet::<T>::inc_providers(&owner);
+        let asset_id = T::AssetManager::gen_asset_id(&owner);
     }: {
         Pallet::<T>::register_regulated_asset(
             owner_origin,
@@ -75,15 +76,21 @@ benchmarks! {
             None
         ).unwrap();
     }
+    verify{
+        assert_last_event::<T>(Event::RegulatedAssetRegistered  {
+             asset_id,
+            }.into()
+        );
+    }
 
 
     issue_sbt{
         let owner = asset_owner::<T>();
         frame_system::Pallet::<T>::inc_providers(&owner);
-        let owner_origin: <T as frame_system::Config>::RuntimeOrigin = RawOrigin::Signed(owner).into();
+        let owner_origin: <T as frame_system::Config>::RuntimeOrigin = RawOrigin::Signed(owner.clone()).into();
         let asset_name =  AssetName(b"Soulbound Token".to_vec());
         let asset_symbol = AssetSymbol(b"SBT".to_vec());
-
+        let asset_id = T::AssetManager::gen_asset_id(&owner);
     }: {
         Pallet::<T>::issue_sbt(
             owner_origin,
@@ -93,6 +100,16 @@ benchmarks! {
             None,
             None,
         ).unwrap();
+    }
+    verify{
+        assert_last_event::<T>(Event::SoulboundTokenIssued  {
+             asset_id,
+             owner,
+             external_url: None,
+             image: None,
+             issued_at: pallet_timestamp::Pallet::<T>::now()
+            }.into()
+        );
     }
 
     set_sbt_expiration {

--- a/pallets/extended-assets/src/test_utils.rs
+++ b/pallets/extended-assets/src/test_utils.rs
@@ -14,7 +14,7 @@ pub fn bob() -> AccountId32 {
     AccountId32::from([2; 32])
 }
 
-pub fn add_asset<T: Config>(owner: &T::AccountId) -> AssetIdOf<T> {
+pub fn register_regular_asset<T: Config>(owner: &T::AccountId) -> AssetIdOf<T> {
     frame_system::Pallet::<T>::inc_providers(owner);
 
     T::AssetManager::register_from(
@@ -31,16 +31,33 @@ pub fn add_asset<T: Config>(owner: &T::AccountId) -> AssetIdOf<T> {
     .expect("Failed to register asset")
 }
 
+pub fn register_regulated_asset<T: Config>(owner: &T::AccountId) -> AssetIdOf<T> {
+    frame_system::Pallet::<T>::inc_providers(owner);
+    let regulated_asset_id = T::AssetManager::gen_asset_id(owner);
+
+    assert_ok!(crate::Pallet::<T>::register_regulated_asset(
+        RawOrigin::Signed(owner.clone()).into(),
+        AssetSymbol(b"TOKEN".to_vec()),
+        AssetName(b"TOKEN".to_vec()),
+        common::Balance::from(0u32),
+        true,
+        true,
+        None,
+        None,
+    ));
+
+    regulated_asset_id
+}
+
 pub fn register_sbt_asset<T: Config>(owner: &T::AccountId) -> AssetIdOf<T> {
-    let asset_name = AssetName(b"Soulbound Token".to_vec());
-    let asset_symbol = AssetSymbol(b"SBT".to_vec());
+    frame_system::Pallet::<T>::inc_providers(owner);
     let sbt_asset_id = T::AssetManager::gen_asset_id(owner);
 
     // Issue SBT
     assert_ok!(crate::Pallet::<T>::issue_sbt(
         RawOrigin::Signed(owner.clone()).into(),
-        asset_symbol,
-        asset_name,
+        AssetSymbol(b"SBT".to_vec()),
+        AssetName(b"Soulbound Token".to_vec()),
         None,
         None,
         None,

--- a/pallets/extended-assets/src/tests.rs
+++ b/pallets/extended-assets/src/tests.rs
@@ -135,12 +135,6 @@ fn test_sbt_only_operationable_by_its_owner() {
 
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
 
-        // assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
-        //     RuntimeOrigin::signed(owner.clone()),
-        //     sbt_asset_id,
-        //     regulated_asset_id
-        // ));
-
         // SBT operations by non-owner should fail
         assert_err!(
             ExtendedAssets::check_permission(&non_owner, &non_owner, &sbt_asset_id, &TRANSFER),

--- a/pallets/extended-assets/src/tests.rs
+++ b/pallets/extended-assets/src/tests.rs
@@ -37,38 +37,12 @@ use permissions::MINT;
 use sp_core::crypto::AccountId32;
 
 #[test]
-fn test_cannot_regulate_already_regulated_asset() {
-    new_test_ext().execute_with(|| {
-        let owner = bob();
-        let asset_id = add_asset::<TestRuntime>(&owner);
-
-        // Regulate the asset for the first time
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
-
-        // Try to regulate the already regulated asset
-        assert_err!(
-            ExtendedAssets::regulate_asset(RuntimeOrigin::signed(owner), asset_id),
-            Error::<TestRuntime>::AssetAlreadyRegulated
-        );
-    })
-}
-
-#[test]
 fn test_tech_account_can_pass_check_permission() {
     new_test_ext().execute_with(|| {
         let owner = bob();
         let tech_account = TechAccountId::Generic("tech".into(), "account".into());
 
-        let asset_id = add_asset::<TestRuntime>(&owner);
-
-        // Regulate the asset
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner),
-            asset_id
-        ));
+        let regulated_asset_id = register_regulated_asset::<TestRuntime>(&owner);
 
         mock::Technical::register_tech_account_id(tech_account.clone()).unwrap();
         let account_id = mock::Technical::tech_account_id_to_account_id(&tech_account).unwrap();
@@ -77,7 +51,7 @@ fn test_tech_account_can_pass_check_permission() {
         assert_ok!(ExtendedAssets::check_permission(
             &account_id,
             &account_id,
-            &asset_id,
+            &regulated_asset_id,
             &TRANSFER
         ));
     })
@@ -88,7 +62,7 @@ fn test_unregulated_asset_can_pass_check_permission() {
     new_test_ext().execute_with(|| {
         let owner = bob();
         let non_owner = alice();
-        let asset_id = add_asset::<TestRuntime>(&owner);
+        let asset_id = register_regular_asset::<TestRuntime>(&owner);
 
         // Unregulated asset can pass permission check
         assert_ok!(ExtendedAssets::check_permission(
@@ -98,43 +72,11 @@ fn test_unregulated_asset_can_pass_check_permission() {
 }
 
 #[test]
-fn test_only_asset_owner_can_regulate_asset() {
-    new_test_ext().execute_with(|| {
-        let owner = bob();
-        let non_owner = alice();
-        let asset_id = add_asset::<TestRuntime>(&owner);
-
-        // Non-owner cannot regulate asset
-        assert_err!(
-            ExtendedAssets::regulate_asset(RuntimeOrigin::signed(non_owner), asset_id),
-            Error::<TestRuntime>::OnlyAssetOwnerCanRegulate
-        );
-
-        // Owner can regulate asset
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner),
-            asset_id
-        ));
-
-        assert_eq!(
-            Assets::asset_infos_v2(asset_id).asset_type,
-            AssetType::Regulated
-        );
-    })
-}
-
-#[test]
 fn test_issue_sbt_succeeds() {
     new_test_ext().execute_with(|| {
         let owner = bob();
         let asset_name = AssetName(b"Soulbound Token".to_vec());
         let asset_symbol = AssetSymbol(b"SBT".to_vec());
-        let asset_id = add_asset::<TestRuntime>(&owner);
-
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
 
         frame_system::Pallet::<TestRuntime>::inc_providers(&owner);
         let sbt_asset_id = Assets::gen_asset_id(&owner);
@@ -158,7 +100,7 @@ fn test_bind_sbt_fails_due_to_invalid_regulated_asset() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
         let owner = bob();
-        let asset_id = add_asset::<TestRuntime>(&owner);
+        let asset_id = register_regular_asset::<TestRuntime>(&owner);
 
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
 
@@ -191,20 +133,13 @@ fn test_sbt_only_operationable_by_its_owner() {
         let owner = bob();
         let non_owner = alice();
 
-        let asset_id = add_asset::<TestRuntime>(&owner);
-
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
-
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
 
-        assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
-            RuntimeOrigin::signed(owner.clone()),
-            sbt_asset_id,
-            asset_id
-        ));
+        // assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
+        //     RuntimeOrigin::signed(owner.clone()),
+        //     sbt_asset_id,
+        //     regulated_asset_id
+        // ));
 
         // SBT operations by non-owner should fail
         assert_err!(
@@ -228,51 +163,13 @@ fn test_sbt_cannot_be_transferred() {
         System::set_block_number(1);
         let owner = bob();
         let non_owner = alice();
-
-        let asset_id = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
-
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
-            RuntimeOrigin::signed(owner.clone()),
-            sbt_asset_id,
-            asset_id
-        ));
 
         assert_err!(
             Assets::transfer(RuntimeOrigin::signed(owner), sbt_asset_id, non_owner, 1),
             Error::<TestRuntime>::SoulboundAssetNotTransferable
         );
     })
-}
-
-#[test]
-fn test_not_allowed_to_regulate_sbt() {
-    new_test_ext().execute_with(|| {
-        System::set_block_number(1);
-        let owner = bob();
-
-        let asset_id = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
-
-        let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
-            RuntimeOrigin::signed(owner.clone()),
-            sbt_asset_id,
-            asset_id
-        ));
-
-        assert_err!(
-            ExtendedAssets::regulate_asset(RuntimeOrigin::signed(owner), sbt_asset_id),
-            Error::<TestRuntime>::NotAllowedToRegulateSoulboundAsset
-        );
-    });
 }
 
 #[test]
@@ -284,11 +181,7 @@ fn test_check_permission_pass_only_if_all_invloved_accounts_have_valid_sbt() {
         let another_account = AccountId32::from([3u8; 32]);
 
         // Regulate an asset
-        let asset_id = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
+        let asset_id = register_regulated_asset::<TestRuntime>(&owner);
 
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
 
@@ -343,11 +236,7 @@ fn test_check_permission_fails_if_one_invloved_account_has_not_valid_sbt_due_to_
         let later_expiration_timestamp = Timestamp::now().saturating_add(200);
 
         // Regulate an asset
-        let regulated_asset_id = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            regulated_asset_id
-        ));
+        let regulated_asset_id = register_regulated_asset::<TestRuntime>(&owner);
 
         let soon_expires_sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
         assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
@@ -409,17 +298,13 @@ fn test_set_sbt_expiration_succeeds() {
         let non_owner = alice();
         let new_expiration_timestamp = Timestamp::now().saturating_add(100);
 
-        let asset_id = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
+        let regulated_asset_id = register_regulated_asset::<TestRuntime>(&owner);
 
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
         assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
             RuntimeOrigin::signed(owner.clone()),
             sbt_asset_id,
-            asset_id
+            regulated_asset_id
         ));
 
         // Update expiration date
@@ -449,17 +334,13 @@ fn test_set_sbt_expiration_fails_for_non_owner() {
         let expiration_timestamp = Timestamp::now().saturating_add(100);
         let new_expiration_timestamp = expiration_timestamp.saturating_add(100);
 
-        let asset_id = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id
-        ));
-
+        let regulated_asset_id = register_regulated_asset::<TestRuntime>(&owner);
         let sbt_asset_id = register_sbt_asset::<TestRuntime>(&owner);
+
         assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
             RuntimeOrigin::signed(owner),
             sbt_asset_id,
-            asset_id
+            regulated_asset_id
         ));
 
         // Attempt to update expiration date by non-owner
@@ -500,44 +381,14 @@ fn test_binding_regulated_asset_to_sbt_succeeds_with_valid_metadata() {
         System::set_block_number(1);
         let owner = bob();
 
-        let asset_name = AssetName(b"Soulbound Token".to_vec());
-        let asset_symbol = AssetSymbol(b"SBT".to_vec());
-
         // 1. Prepare two new regulated assets
 
-        let asset_id_1 = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id_1
-        ));
-
-        let asset_id_2 = add_asset::<TestRuntime>(&owner);
-        assert_ok!(ExtendedAssets::regulate_asset(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_id_2
-        ));
+        let regulated_asset_id_1 = register_regulated_asset::<TestRuntime>(&owner);
+        let regulated_asset_id_2 = register_regulated_asset::<TestRuntime>(&owner);
 
         // 2. Issue two new SBTs
 
-        assert_ok!(ExtendedAssets::issue_sbt(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_symbol.clone(),
-            asset_name.clone(),
-            None,
-            None,
-            None,
-        ));
         let sbt_asset_id_1 = register_sbt_asset::<TestRuntime>(&owner);
-
-        assert_ok!(ExtendedAssets::issue_sbt(
-            RuntimeOrigin::signed(owner.clone()),
-            asset_symbol,
-            asset_name,
-            None,
-            None,
-            None,
-        ));
-
         let sbt_asset_id_2 = register_sbt_asset::<TestRuntime>(&owner);
 
         // 3. Bind each regulated asset to one SBT
@@ -545,13 +396,13 @@ fn test_binding_regulated_asset_to_sbt_succeeds_with_valid_metadata() {
         assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
             RuntimeOrigin::signed(owner.clone()),
             sbt_asset_id_1,
-            asset_id_1
+            regulated_asset_id_1
         ));
 
         assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
             RuntimeOrigin::signed(owner.clone()),
             sbt_asset_id_2,
-            asset_id_2
+            regulated_asset_id_2
         ));
 
         // 4. Check that the SBTs have the correct asset bindings
@@ -563,13 +414,13 @@ fn test_binding_regulated_asset_to_sbt_succeeds_with_valid_metadata() {
             AssetId32<PredefinedAssetId>,
             MockMaxRegulatedAssetsPerSBT,
         > = BoundedBTreeSet::new();
-        regulated_assets_1.try_insert(asset_id_1).unwrap();
+        regulated_assets_1.try_insert(regulated_asset_id_1).unwrap();
 
         let mut regulated_assets_2: BoundedBTreeSet<
             AssetId32<PredefinedAssetId>,
             MockMaxRegulatedAssetsPerSBT,
         > = BoundedBTreeSet::new();
-        regulated_assets_2.try_insert(asset_id_2).unwrap();
+        regulated_assets_2.try_insert(regulated_asset_id_2).unwrap();
 
         assert_eq!(sbt_metadata_1.regulated_assets, regulated_assets_1);
         assert_eq!(sbt_metadata_2.regulated_assets, regulated_assets_2);
@@ -581,7 +432,7 @@ fn test_binding_regulated_asset_to_sbt_succeeds_with_valid_metadata() {
         assert_ok!(ExtendedAssets::bind_regulated_asset_to_sbt(
             RuntimeOrigin::signed(owner),
             sbt_asset_id_2,
-            asset_id_1
+            regulated_asset_id_1
         ));
 
         let after_sbt_metadata_1 = ExtendedAssets::soulbound_asset(sbt_asset_id_1).unwrap();
@@ -591,8 +442,12 @@ fn test_binding_regulated_asset_to_sbt_succeeds_with_valid_metadata() {
             AssetId32<PredefinedAssetId>,
             MockMaxRegulatedAssetsPerSBT,
         > = BoundedBTreeSet::new();
-        after_regulated_assets_2.try_insert(asset_id_2).unwrap();
-        after_regulated_assets_2.try_insert(asset_id_1).unwrap();
+        after_regulated_assets_2
+            .try_insert(regulated_asset_id_2)
+            .unwrap();
+        after_regulated_assets_2
+            .try_insert(regulated_asset_id_1)
+            .unwrap();
 
         assert_eq!(
             after_sbt_metadata_1.regulated_assets,

--- a/pallets/extended-assets/src/weights.rs
+++ b/pallets/extended-assets/src/weights.rs
@@ -63,7 +63,7 @@ use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {
-    fn regulate_asset() -> Weight;
+    fn register_regulated_asset() -> Weight;
 	fn issue_sbt() -> Weight;
 	fn set_sbt_expiration() -> Weight;
 	fn bind_regulated_asset_to_sbt() -> Weight;
@@ -78,7 +78,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof Skipped: Assets AssetInfosV2 (max_values: None, max_size: None, mode: Measured)
 	/// Storage: ExtendedAssets SoulboundAsset (r:1 w:0)
 	/// Proof: ExtendedAssets SoulboundAsset (max_values: None, max_size: Some(322091), added: 324566, mode: MaxEncodedLen)
-	fn regulate_asset() -> Weight {
+	fn register_regulated_asset() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1215`
 		//  Estimated: `331946`
@@ -145,7 +145,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 
 impl WeightInfo for () {
-    fn regulate_asset() -> Weight {
+    fn register_regulated_asset() -> Weight {
         Weight::from_parts(23_000_000, 331946)
             .saturating_add(RocksDbWeight::get().reads(3_u64))
             .saturating_add(RocksDbWeight::get().writes(1_u64))

--- a/pallets/extended-assets/src/weights.rs
+++ b/pallets/extended-assets/src/weights.rs
@@ -72,20 +72,26 @@ pub trait WeightInfo {
 /// Weight functions for `extended_assets`.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	/// Storage: Assets AssetOwners (r:1 w:0)
+	/// Storage: System Account (r:1 w:1)
+	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
+	/// Storage: Assets AssetOwners (r:1 w:1)
 	/// Proof Skipped: Assets AssetOwners (max_values: None, max_size: None, mode: Measured)
-	/// Storage: Assets AssetInfosV2 (r:1 w:1)
+	/// Storage: Permissions Owners (r:2 w:2)
+	/// Proof Skipped: Permissions Owners (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Permissions Permissions (r:2 w:1)
+	/// Proof Skipped: Permissions Permissions (max_values: None, max_size: None, mode: Measured)
+	/// Storage: Assets AssetInfosV2 (r:0 w:1)
 	/// Proof Skipped: Assets AssetInfosV2 (max_values: None, max_size: None, mode: Measured)
-	/// Storage: ExtendedAssets SoulboundAsset (r:1 w:0)
-	/// Proof: ExtendedAssets SoulboundAsset (max_values: None, max_size: Some(322091), added: 324566, mode: MaxEncodedLen)
+	/// Storage: Assets AssetInfos (r:0 w:1)
+	/// Proof Skipped: Assets AssetInfos (max_values: None, max_size: None, mode: Measured)
 	fn register_regulated_asset() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1215`
-		//  Estimated: `331946`
-		// Minimum execution time: 22_000 nanoseconds.
-		Weight::from_parts(23_000_000, 331946)
-			.saturating_add(T::DbWeight::get().reads(3))
-			.saturating_add(T::DbWeight::get().writes(1))
+		//  Measured:  `2100`
+		//  Estimated: `25478`
+		// Minimum execution time: 77_000 nanoseconds.
+		Weight::from_parts(78_000_000, 25478)
+			.saturating_add(T::DbWeight::get().reads(6))
+			.saturating_add(T::DbWeight::get().writes(7))
 	}
 	/// Storage: Timestamp Now (r:1 w:0)
 	/// Proof: Timestamp Now (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
@@ -146,9 +152,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 impl WeightInfo for () {
     fn register_regulated_asset() -> Weight {
-        Weight::from_parts(23_000_000, 331946)
-            .saturating_add(RocksDbWeight::get().reads(3_u64))
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_parts(78_000_000, 25478)
+			.saturating_add(RocksDbWeight::get().reads(6))
+			.saturating_add(RocksDbWeight::get().writes(7))
     }
 	
 	fn issue_sbt() -> Weight {

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -941,14 +941,12 @@ impl ExtBuilder {
         self
     }
 
-    #[cfg(feature = "wip")] // DEFI-R
     pub fn with_permissioned_xyk_pool(mut self) -> Self {
         self = self.with_xyk_pool();
         self.is_permissioned_xyk_pool = true;
         self
     }
 
-    #[cfg(feature = "wip")] // DEFI-R
     fn prepare_asset_for_permissioned_pool(owner: &AccountId, asset_id: &AssetId) {
         use extended_assets::test_utils::register_sbt_asset;
         use frame_support::assert_ok;
@@ -956,7 +954,7 @@ impl ExtBuilder {
         System::set_block_number(1);
         let owner_origin = RuntimeOrigin::signed(owner.clone());
         if !ExtendedAssets::is_asset_regulated(asset_id) {
-            ExtendedAssets::regulate_asset(owner_origin.clone(), *asset_id)
+            assets::Pallet::<Runtime>::update_asset_type(asset_id, &common::AssetType::Regulated)
                 .expect("Failed to regulate Asset");
         }
 
@@ -1078,7 +1076,6 @@ impl ExtBuilder {
                 )
                 .unwrap();
                 if self.is_permissioned_xyk_pool {
-                    #[cfg(feature = "wip")] // DEFI-R
                     Self::prepare_asset_for_permissioned_pool(&owner, &asset.into());
                 }
                 assets::Pallet::<Runtime>::mint_to(&asset.into(), &owner, &owner, mint_amount)

--- a/pallets/liquidity-proxy/src/mock.rs
+++ b/pallets/liquidity-proxy/src/mock.rs
@@ -163,7 +163,6 @@ construct_runtime! {
         MBCPool: multicollateral_bonding_curve_pool::{Pallet, Call, Storage, Event<T>},
         CeresLiquidityLocker: ceres_liquidity_locker::{Pallet, Call, Storage, Event<T>},
         DemeterFarmingPlatform: demeter_farming_platform::{Pallet, Call, Storage, Event<T>},
-        #[cfg(feature = "wip")] // DEFI-R
         ExtendedAssets: extended_assets::{Pallet, Call, Storage, Event<T>},
     }
 }
@@ -293,7 +292,6 @@ impl demeter_farming_platform::Config for Runtime {
     type AssetInfoProvider = assets::Pallet<Runtime>;
 }
 
-#[cfg(feature = "wip")] // DEFI-R
 impl extended_assets::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type AssetInfoProvider = assets::Pallet<Runtime>;
@@ -323,9 +321,6 @@ impl pool_xyk::Config for Runtime {
     type GetChameleonPool = common::mock::GetChameleonPool;
     type GetChameleonPoolBaseAssetId = common::mock::GetChameleonPoolBaseAssetId;
     type AssetInfoProvider = assets::Pallet<Runtime>;
-    #[cfg(not(feature = "wip"))] // DEFI-R
-    type AssetRegulator = ();
-    #[cfg(feature = "wip")] // DEFI-R
     type AssetRegulator = extended_assets::Pallet<Runtime>;
     type IrreducibleReserve = GetXykIrreducibleReservePercent;
     type WeightInfo = ();

--- a/pallets/liquidity-proxy/src/tests.rs
+++ b/pallets/liquidity-proxy/src/tests.rs
@@ -502,7 +502,6 @@ fn test_swap_with_desired_output_returns_precise_amount() {
     });
 }
 
-#[cfg(feature = "wip")] // DEFI-R
 #[test]
 fn test_swap_for_permissioned_pool_with_desired_output_returns_precise_amount() {
     let mut ext = ExtBuilder::default().with_permissioned_xyk_pool().build();
@@ -560,7 +559,6 @@ fn test_swap_with_multi_steps_desired_output_return_precise_amount() {
     });
 }
 
-#[cfg(feature = "wip")] // DEFI-R
 #[test]
 fn test_swap_for_permissioned_pool_with_multi_steps_desired_output_return_precise_amount() {
     let mut ext = ExtBuilder::default().with_permissioned_xyk_pool().build();
@@ -618,7 +616,6 @@ fn test_swap_with_desired_input_return_precise_amount() {
     });
 }
 
-#[cfg(feature = "wip")] // DEFI-R
 #[test]
 fn test_swap_for_permissioned_pool_with_desired_input_return_precise_amount() {
     let mut ext = ExtBuilder::default().with_permissioned_xyk_pool().build();
@@ -675,7 +672,6 @@ fn test_swap_with_multi_steps_desired_input_return_precise_amount() {
     });
 }
 
-#[cfg(feature = "wip")] // DEFI-R
 #[test]
 fn test_swap_for_permissioned_pool_with_multi_steps_desired_input_return_precise_amount() {
     let mut ext = ExtBuilder::default().with_permissioned_xyk_pool().build();

--- a/pallets/pool-xyk/src/tests.rs
+++ b/pallets/pool-xyk/src/tests.rs
@@ -4106,7 +4106,7 @@ fn test_pool_fails_with_regulated_asset() {
             DEFAULT_BALANCE_PRECISION,
             Balance::from(balance!(10)),
             true,
-            common::AssetType::Regular,
+            common::AssetType::Regulated,
             None,
             None,
         ));
@@ -4139,10 +4139,10 @@ fn test_pool_fails_with_regulated_asset() {
             balance!(900000)
         ));
 
-        assert_ok!(extended_assets::Pallet::<Runtime>::regulate_asset(
-            RuntimeOrigin::signed(ALICE()),
-            Apple.into(),
-        ));
+        // assert_ok!(extended_assets::Pallet::<Runtime>::regulate_asset(
+        //     RuntimeOrigin::signed(ALICE()),
+        //     Apple.into(),
+        // ));
 
         assert_ok!(trading_pair::Pallet::<Runtime>::register(
             RuntimeOrigin::signed(BOB()),
@@ -4240,7 +4240,7 @@ fn test_pool_works_with_regulated_asset() {
             DEFAULT_BALANCE_PRECISION,
             Balance::from(balance!(10)),
             true,
-            common::AssetType::Regular,
+            common::AssetType::Regulated,
             None,
             None,
         ));
@@ -4271,11 +4271,6 @@ fn test_pool_works_with_regulated_asset() {
             &ALICE(),
             &BOB(),
             balance!(900000)
-        ));
-
-        assert_ok!(extended_assets::Pallet::<Runtime>::regulate_asset(
-            RuntimeOrigin::signed(ALICE()),
-            Apple.into(),
         ));
 
         assert_ok!(trading_pair::Pallet::<Runtime>::register(

--- a/pallets/pool-xyk/src/tests.rs
+++ b/pallets/pool-xyk/src/tests.rs
@@ -4139,11 +4139,6 @@ fn test_pool_fails_with_regulated_asset() {
             balance!(900000)
         ));
 
-        // assert_ok!(extended_assets::Pallet::<Runtime>::regulate_asset(
-        //     RuntimeOrigin::signed(ALICE()),
-        //     Apple.into(),
-        // ));
-
         assert_ok!(trading_pair::Pallet::<Runtime>::register(
             RuntimeOrigin::signed(BOB()),
             DEX_A_ID,


### PR DESCRIPTION
## Changes:

- Altered `regulate_asset` extrinsic to `register_regulated_asset`
- Removed unused errors and modified tests & events due to this change
- Ran benchmarking and updated weights