### PR TITLE
Fix: remove redundant arg

### DIFF
--- a/pallets/vested-rewards/src/benchmarking.rs
+++ b/pallets/vested-rewards/src/benchmarking.rs
@@ -255,7 +255,7 @@ benchmarks! {
                 per_period: balance!(1),
             });
 
-    }: _(RawOrigin::Signed(caller.clone()), asset_id, receiver, schedule)
+    }: _(RawOrigin::Signed(caller.clone()), receiver, schedule)
     verify {
         assert!(VestingSchedules::<T>::contains_key(bob::<T>()));
     }
@@ -323,7 +323,7 @@ benchmarks! {
         schedules.try_push(vesting_schedule_locked.clone()).expect("Error while push to BoundedVec");
         <VestingSchedules<T>>::insert(caller.clone(), schedules);
         frame_system::Pallet::<T>::set_block_number(T::BlockNumber::from(2_u32));
-    }: _(RawOrigin::Signed(caller.clone()), asset_id, T::Lookup::unlookup(caller.clone()), None, vesting_schedule_locked)
+    }: _(RawOrigin::Signed(caller.clone()), T::Lookup::unlookup(caller.clone()), None, vesting_schedule_locked)
     verify {
         frame_system::Pallet::<T>::set_block_number(T::BlockNumber::from(3_u32));
         assert_ok!(VestedRewards::<T>::claim_unlocked(RawOrigin::Signed(caller.clone()).into(), asset_id));

--- a/pallets/vested-rewards/src/lib.rs
+++ b/pallets/vested-rewards/src/lib.rs
@@ -830,7 +830,6 @@ pub mod pallet {
         #[pallet::weight(<T as Config>::WeightInfo::vested_transfer())]
         pub fn vested_transfer(
             origin: OriginFor<T>,
-            asset_id: AssetIdOf<T>,
             dest: <T::Lookup as StaticLookup>::Source,
             schedule: VestingScheduleOf<T>,
         ) -> DispatchResultWithPostInfo {
@@ -841,7 +840,7 @@ pub mod pallet {
 
                 if to == from {
                     ensure!(
-                        T::Currency::free_balance(asset_id, &from)
+                        T::Currency::free_balance(schedule.asset_id(), &from)
                             >= VestingScheduleVariant::total_amount(&schedule)
                                 .ok_or(Error::<T>::ArithmeticError)?,
                         Error::<T>::InsufficientBalanceToLock,
@@ -907,7 +906,6 @@ pub mod pallet {
         #[pallet::weight(<T as Config>::WeightInfo::unlock_pending_schedule_by_manager())]
         pub fn unlock_pending_schedule_by_manager(
             origin: OriginFor<T>,
-            asset_id: AssetIdOf<T>,
             dest: <T::Lookup as StaticLookup>::Source,
             start: Option<T::BlockNumber>,
             mut filter_schedule: VestingScheduleOf<T>,

--- a/pallets/vested-rewards/src/tests.rs
+++ b/pallets/vested-rewards/src/tests.rs
@@ -1046,7 +1046,6 @@ fn linear_vested_transfer_works() {
             });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule.clone()
         ));
@@ -1059,7 +1058,6 @@ fn linear_vested_transfer_works() {
         ));
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_locked.clone()
         ));
@@ -1107,24 +1105,17 @@ fn self_linear_vesting() {
         });
 
         assert_noop!(
-            VestedRewards::vested_transfer(
-                RuntimeOrigin::signed(alice()),
-                DOT,
-                alice(),
-                bad_schedule
-            ),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), alice(), bad_schedule),
             crate::Error::<Runtime>::InsufficientBalanceToLock
         );
 
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             alice(),
             schedule.clone()
         ));
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            KSM,
             alice(),
             schedule_ksm.clone()
         ));
@@ -1157,7 +1148,6 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule
         ));
@@ -1171,7 +1161,6 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            KSM,
             bob(),
             schedule_ksm
         ));
@@ -1189,7 +1178,6 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             another_schedule
         ));
@@ -1206,7 +1194,6 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             another_schedule_locked
         ));
@@ -1222,7 +1209,6 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            KSM,
             bob(),
             another_schedule_ksm
         ));
@@ -1257,7 +1243,6 @@ fn cannot_use_fund_if_not_claimed_from_linear() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule
         ));
@@ -1272,7 +1257,6 @@ fn cannot_use_fund_if_not_claimed_from_linear() {
             });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_locked
         ));
@@ -1306,14 +1290,12 @@ fn linear_vesting_unlock_correct() {
 
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_locked.clone()
         ));
         assert_err!(
             VestedRewards::unlock_pending_schedule_by_manager(
                 RuntimeOrigin::signed(bob()),
-                DOT,
                 bob(),
                 None,
                 schedule_locked.clone(),
@@ -1323,7 +1305,6 @@ fn linear_vesting_unlock_correct() {
         run_to_block(12);
         assert_ok!(VestedRewards::unlock_pending_schedule_by_manager(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             None,
             schedule_locked,
@@ -1363,16 +1344,11 @@ fn linear_vested_transfer_fails_if_zero_period_or_count() {
                 per_period: 100,
             });
         assert_noop!(
-            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), DOT, bob(), schedule),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), schedule),
             Error::<Runtime>::ZeroVestingPeriod
         );
         assert_noop!(
-            VestedRewards::vested_transfer(
-                RuntimeOrigin::signed(alice()),
-                DOT,
-                bob(),
-                schedule_locked
-            ),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), schedule_locked),
             Error::<Runtime>::ZeroVestingPeriod
         );
 
@@ -1393,16 +1369,11 @@ fn linear_vested_transfer_fails_if_zero_period_or_count() {
                 per_period: 100,
             });
         assert_noop!(
-            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), DOT, bob(), schedule),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), schedule),
             Error::<Runtime>::ZeroVestingPeriodCount
         );
         assert_noop!(
-            VestedRewards::vested_transfer(
-                RuntimeOrigin::signed(alice()),
-                DOT,
-                bob(),
-                schedule_locked
-            ),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), schedule_locked),
             Error::<Runtime>::ZeroVestingPeriodCount
         );
     });
@@ -1429,16 +1400,11 @@ fn vested_transfer_fails_if_transfer_err() {
                 per_period: 100,
             });
         assert_noop!(
-            VestedRewards::vested_transfer(RuntimeOrigin::signed(bob()), DOT, alice(), schedule),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(bob()), alice(), schedule),
             tokens::Error::<Runtime>::BalanceTooLow
         );
         assert_noop!(
-            VestedRewards::vested_transfer(
-                RuntimeOrigin::signed(bob()),
-                DOT,
-                alice(),
-                schedule_locked
-            ),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(bob()), alice(), schedule_locked),
             tokens::Error::<Runtime>::BalanceTooLow
         );
     });
@@ -1465,16 +1431,11 @@ fn vested_linear_transfer_and_unlock_pending_fails_if_overflow() {
                 per_period: Balance::MAX,
             });
         assert_noop!(
-            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), DOT, bob(), schedule),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), schedule),
             ArithmeticError::<Runtime>,
         );
         assert_noop!(
-            VestedRewards::vested_transfer(
-                RuntimeOrigin::signed(alice()),
-                DOT,
-                bob(),
-                schedule_locked
-            ),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), schedule_locked),
             ArithmeticError::<Runtime>,
         );
 
@@ -1489,14 +1450,12 @@ fn vested_linear_transfer_and_unlock_pending_fails_if_overflow() {
             });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_locked_right.clone()
         ));
         assert_noop!(
             VestedRewards::unlock_pending_schedule_by_manager(
                 RuntimeOrigin::signed(alice()),
-                DOT,
                 bob(),
                 Some(u64::MAX),
                 schedule_locked_right
@@ -1514,12 +1473,7 @@ fn vested_linear_transfer_and_unlock_pending_fails_if_overflow() {
             });
 
         assert_noop!(
-            VestedRewards::vested_transfer(
-                RuntimeOrigin::signed(alice()),
-                DOT,
-                bob(),
-                another_schedule
-            ),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(alice()), bob(), another_schedule),
             ArithmeticError::<Runtime>,
         );
 
@@ -1536,7 +1490,6 @@ fn vested_linear_transfer_and_unlock_pending_fails_if_overflow() {
         assert_noop!(
             VestedRewards::vested_transfer(
                 RuntimeOrigin::signed(alice()),
-                DOT,
                 bob(),
                 schedule_locked_right.clone()
             ),
@@ -1556,7 +1509,7 @@ fn vested_transfer_check_for_min() {
             per_period: 3,
         });
         assert_noop!(
-            VestedRewards::vested_transfer(RuntimeOrigin::signed(bob()), DOT, alice(), schedule),
+            VestedRewards::vested_transfer(RuntimeOrigin::signed(bob()), alice(), schedule),
             Error::<Runtime>::AmountLow
         );
     });
@@ -1591,27 +1544,23 @@ fn claim_linear_works() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule
         ));
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_locked.clone()
         ));
 
         assert_ok!(VestedRewards::unlock_pending_schedule_by_manager(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             Some(0_u64),
             schedule_locked
         ),);
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_ksm
         ));
@@ -1674,7 +1623,6 @@ fn claim_for_works() {
 
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule
         ));
@@ -1721,7 +1669,6 @@ fn update_vesting_schedules_works() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule
         ));
@@ -1735,7 +1682,6 @@ fn update_vesting_schedules_works() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            KSM,
             bob(),
             schedule_ksm
         ));
@@ -1751,7 +1697,6 @@ fn update_vesting_schedules_works() {
             });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule_locked
         ));
@@ -1831,7 +1776,6 @@ fn multiple_vesting_linear_schedule_claim_works() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule.clone()
         ));
@@ -1844,7 +1788,6 @@ fn multiple_vesting_linear_schedule_claim_works() {
         });
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             schedule2.clone()
         ));
@@ -1889,14 +1832,12 @@ fn exceeding_maximum_schedules_should_fail() {
         for _ in 0u32..MaxVestingSchedules::get() {
             assert_ok!(VestedRewards::vested_transfer(
                 RuntimeOrigin::signed(alice()),
-                DOT,
                 bob(),
                 schedule.clone()
             ));
         }
 
         let create = RuntimeCall::VestedRewards(crate::Call::<Runtime>::vested_transfer {
-            asset_id: DOT,
             dest: bob(),
             schedule: schedule.clone(),
         });
@@ -1929,7 +1870,6 @@ fn cliff_vesting_linear_works() {
         assert_eq!(Tokens::free_balance(DOT, &bob()), 0);
         assert_ok!(VestedRewards::vested_transfer(
             RuntimeOrigin::signed(alice()),
-            DOT,
             bob(),
             cliff_schedule
         ));


### PR DESCRIPTION
Remove redundant arg `asset_id` from `vested_transfer` and `unlock_pending_schedule_by_manager`, because it's contained in `schedule`