### PR TITLE
Prepare release 4.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "framenode"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "ahash 0.8.5",
  "assert_cmd",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "framenode-chain-spec"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "common",
  "faucet",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "framenode-runtime"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "apollo-platform",
  "assets",

--- a/common/src/mock.rs
+++ b/common/src/mock.rs
@@ -246,7 +246,7 @@ macro_rules! mock_assets_config {
 macro_rules! mock_band_config {
     ($runtime:ty, $on_new_symbol_relayed_hook:ty, $on_symbol_disabled_hook:ty) => {
         frame_support::parameter_types! {
-            pub const GetBandRateStalePeriod: u64 = 60*5*1000; // 5 minutes
+            pub const GetBandRateStalePeriod: u64 = 60*10*1000; // 10 minutes
             pub const GetBandRateStaleBlockPeriod: u64 = 600;
         }
         impl band::Config for $runtime {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framenode"
-version = "4.3.1"
+version = "4.3.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"

--- a/node/chain_spec/Cargo.toml
+++ b/node/chain_spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framenode-chain-spec"
-version = "4.3.1"
+version = "4.3.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/pallets/bridge-proxy/src/lib.rs
+++ b/pallets/bridge-proxy/src/lib.rs
@@ -496,6 +496,14 @@ impl<T: Config> Pallet<T> {
             network_id,
         ))
     }
+
+    pub fn reset_locked_assets(
+        network_id: GenericNetworkId,
+        asset_id: AssetIdOf<T>,
+    ) -> DispatchResult {
+        LockedAssets::<T>::remove(network_id, asset_id);
+        Ok(())
+    }
 }
 
 impl<T: Config> BridgeAssetLocker<T::AccountId> for Pallet<T> {

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -1826,6 +1826,14 @@ impl<T: Config> Pallet<T> {
         }
         Ok(network_id)
     }
+
+    pub fn remove_thischain_asset(
+        network_id: T::NetworkId,
+        asset_id: AssetIdOf<T>,
+    ) -> DispatchResult {
+        RegisteredAsset::<T>::remove(network_id, asset_id);
+        Ok(())
+    }
 }
 
 impl<T: Config> BridgeApp<T::AccountId, EthAddress, T::AssetId, Balance> for Pallet<T> {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ license = "BSD-4-Clause"
 homepage = "https://sora.org"
 repository = "https://github.com/sora-xor/sora2-network"
 name = "framenode-runtime"
-version = "4.3.1"
+version = "4.3.2"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -255,10 +255,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("sora-substrate"),
     impl_name: create_runtime_str!("sora-substrate"),
     authoring_version: 1,
-    spec_version: 103,
+    spec_version: 104,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 103,
+    transaction_version: 104,
     state_version: 0,
 };
 
@@ -1969,7 +1969,7 @@ impl oracle_proxy::Config for Runtime {
 }
 
 parameter_types! {
-    pub const GetBandRateStalePeriod: Moment = 60*5*1000; // 5 minutes
+    pub const GetBandRateStalePeriod: Moment = 60*10*1000; // 10 minutes
     pub const GetBandRateStaleBlockPeriod: u32 = 600; // 1 hour in blocks
     pub const BandMaxRelaySymbols: u32 = 100;
 }

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -103,6 +103,12 @@ impl OnRuntimeUpgrade for DenominateVXor {
                 }
             }
 
+            crate::EthBridge::remove_thischain_asset(0, common::VXOR)?;
+            crate::BridgeProxy::reset_locked_assets(
+                bridge_types::GenericNetworkId::EVMLegacy(0),
+                common::VXOR,
+            )?;
+
             DispatchResult::Ok(())
         });
         if let Err(err) = result {


### PR DESCRIPTION
### Notes
* Band rate stale period was updated from 5 minutes to 10 minutes. Stale block period is not changed, so migration is not required
* Migration will be repeated