### PR TITLE
Presto: publish Crop Receipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7756,6 +7756,7 @@ dependencies = [
  "dex-manager",
  "frame-support",
  "frame-system",
+ "order-book",
  "orml-currencies",
  "orml-tokens",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -372,7 +372,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -811,7 +811,7 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasm-timer",
 ]
 
@@ -831,7 +831,7 @@ dependencies = [
  "sp-beefy",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2911,7 +2911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "uint",
 ]
 
@@ -3372,7 +3372,7 @@ dependencies = [
  "sp-std",
  "sp-storage",
  "sp-trie",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "thousands",
 ]
 
@@ -4134,7 +4134,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -4579,7 +4579,7 @@ dependencies = [
  "rand 0.8.5",
  "rtcp",
  "rtp",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "waitgroup",
  "webrtc-srtp",
@@ -4771,7 +4771,7 @@ dependencies = [
  "pin-project",
  "rustls-native-certs",
  "soketto",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -4802,7 +4802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
 ]
@@ -4852,7 +4852,7 @@ dependencies = [
  "beef",
  "serde",
  "serde_json",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -5123,7 +5123,7 @@ dependencies = [
  "sec1",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "unsigned-varint",
  "void",
  "zeroize",
@@ -5152,7 +5152,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "unsigned-varint",
  "void",
 ]
@@ -5188,7 +5188,7 @@ dependencies = [
  "prost-build",
  "prost-codec",
  "smallvec",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "void",
 ]
 
@@ -5206,7 +5206,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "zeroize",
 ]
 
@@ -5232,7 +5232,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "uint",
  "unsigned-varint",
  "void",
@@ -5308,7 +5308,7 @@ dependencies = [
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "x25519-dalek 1.1.1",
  "zeroize",
 ]
@@ -5346,7 +5346,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.8.5",
  "rustls 0.20.9",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -5385,7 +5385,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "smallvec",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "void",
 ]
@@ -5430,7 +5430,7 @@ dependencies = [
  "rcgen 0.10.0",
  "ring 0.16.20",
  "rustls 0.20.9",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "webpki 0.22.4",
  "x509-parser 0.14.0",
  "yasna",
@@ -5474,7 +5474,7 @@ dependencies = [
  "rcgen 0.9.3",
  "serde",
  "stun",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tinytemplate",
  "tokio",
  "tokio-util",
@@ -5510,7 +5510,7 @@ dependencies = [
  "libp2p-core 0.38.0",
  "log",
  "parking_lot 0.12.3",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "yamux",
 ]
 
@@ -6279,7 +6279,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "paste",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -6293,7 +6293,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -7441,7 +7441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "ucd-trie",
 ]
 
@@ -7767,6 +7767,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "technical",
+ "trading-pair",
 ]
 
 [[package]]
@@ -7829,7 +7830,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "toml",
 ]
 
@@ -7886,7 +7887,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot 0.12.3",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -7953,7 +7954,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "prost",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "unsigned-varint",
 ]
 
@@ -8146,7 +8147,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.20.9",
  "slab",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tinyvec",
  "tracing",
  "webpki 0.22.4",
@@ -8334,7 +8335,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -8595,7 +8596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1919efd6d4a6a85d13388f9487549bb8e359f17198cc03ffd72f79b553873691"
 dependencies = [
  "bytes",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "webrtc-util",
 ]
 
@@ -8610,7 +8611,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "nix 0.24.3",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -8634,7 +8635,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "serde",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "webrtc-util",
 ]
 
@@ -8827,7 +8828,7 @@ dependencies = [
  "log",
  "sp-core",
  "sp-wasm-interface",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -8930,7 +8931,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-version",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tiny-bip39",
  "tokio",
 ]
@@ -9009,7 +9010,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9038,7 +9039,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9076,7 +9077,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9147,7 +9148,7 @@ dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasm-instrument",
  "wasmi",
 ]
@@ -9219,7 +9220,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9249,7 +9250,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9289,7 +9290,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "unsigned-varint",
  "zeroize",
 ]
@@ -9309,7 +9310,7 @@ dependencies = [
  "sc-network-common 0.10.0-dev (git+https://github.com/sora-xor/substrate.git?branch=polkadot-v0.9.38)",
  "sp-blockchain",
  "sp-runtime",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "unsigned-varint",
 ]
 
@@ -9336,7 +9337,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9362,7 +9363,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9401,7 +9402,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9433,7 +9434,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9596,7 +9597,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-version",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9636,7 +9637,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-version",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio-stream",
 ]
 
@@ -9700,7 +9701,7 @@ dependencies = [
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -9729,7 +9730,7 @@ dependencies = [
  "sc-client-db",
  "sc-utils 4.0.0-dev (git+https://github.com/sora-xor/substrate.git?branch=polkadot-v0.9.38)",
  "sp-core",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -9767,7 +9768,7 @@ dependencies = [
  "sc-utils 4.0.0-dev (git+https://github.com/sora-xor/substrate.git?branch=polkadot-v0.9.38)",
  "serde",
  "serde_json",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasm-timer",
 ]
 
@@ -9796,7 +9797,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-tracing",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -9837,7 +9838,7 @@ dependencies = [
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9851,7 +9852,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-runtime",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -9986,7 +9987,7 @@ checksum = "4d22a5ef407871893fd72b4562ee15e4742269b173959db4b8df6f538c414e13"
 dependencies = [
  "rand 0.8.5",
  "substring",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "url",
 ]
 
@@ -10391,7 +10392,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -10477,7 +10478,7 @@ dependencies = [
  "sp-database",
  "sp-runtime",
  "sp-state-machine",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -10495,7 +10496,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-version",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -10601,7 +10602,7 @@ dependencies = [
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tiny-bip39",
  "zeroize",
 ]
@@ -10700,7 +10701,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -10753,7 +10754,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-externalities",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -10761,7 +10762,7 @@ name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
 source = "git+https://github.com/sora-xor/substrate.git?branch=polkadot-v0.9.38#b12c8d200054c92586ec33f5dfc5d0e109958004"
 dependencies = [
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "zstd",
 ]
 
@@ -10780,7 +10781,7 @@ dependencies = [
  "sp-debug-derive 5.0.0 (git+https://github.com/sora-xor/substrate.git?branch=polkadot-v0.9.38)",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -10921,7 +10922,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-std",
  "sp-trie",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -10955,7 +10956,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -11012,7 +11013,7 @@ dependencies = [
  "schnellru",
  "sp-core",
  "sp-std",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tracing",
  "trie-db",
  "trie-root",
@@ -11032,7 +11033,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -11252,7 +11253,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.16.20",
  "subtle",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "url",
  "webrtc-util",
@@ -11354,7 +11355,7 @@ dependencies = [
  "hyper",
  "log",
  "prometheus",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -11528,7 +11529,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl 1.0.60",
+ "thiserror-impl 1.0.64",
 ]
 
 [[package]]
@@ -11639,7 +11640,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hash",
  "sha2 0.10.8",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -11997,7 +11998,7 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tinyvec",
  "tokio",
  "tracing",
@@ -12018,7 +12019,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
  "trust-dns-proto",
@@ -12081,7 +12082,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.16.20",
  "stun",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "webrtc-util",
 ]
@@ -12449,7 +12450,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "tempfile",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasm-opt-cxx-sys",
  "wasm-opt-sys",
 ]
@@ -12609,7 +12610,7 @@ dependencies = [
  "log",
  "object 0.29.0",
  "target-lexicon",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasmparser",
  "wasmtime-environ",
 ]
@@ -12628,7 +12629,7 @@ dependencies = [
  "object 0.29.0",
  "serde",
  "target-lexicon",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasmparser",
  "wasmtime-types",
 ]
@@ -12651,7 +12652,7 @@ dependencies = [
  "rustix 0.35.16",
  "serde",
  "target-lexicon",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasmtime-environ",
  "wasmtime-jit-debug",
  "wasmtime-runtime",
@@ -12687,7 +12688,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rustix 0.35.16",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -12702,7 +12703,7 @@ checksum = "d23d61cb4c46e837b431196dd06abb11731541021916d03476a178b54dc07aeb"
 dependencies = [
  "cranelift-entity",
  "serde",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "wasmparser",
 ]
 
@@ -12776,7 +12777,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "stun",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "time",
  "tokio",
  "turn",
@@ -12801,7 +12802,7 @@ dependencies = [
  "bytes",
  "derive_builder",
  "log",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "webrtc-sctp",
  "webrtc-util",
@@ -12839,7 +12840,7 @@ dependencies = [
  "sha2 0.10.8",
  "signature 1.6.4",
  "subtle",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "webpki 0.21.4",
  "webrtc-util",
@@ -12861,7 +12862,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stun",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "turn",
  "url",
@@ -12879,7 +12880,7 @@ checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
 dependencies = [
  "log",
  "socket2 0.4.10",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "webrtc-util",
 ]
@@ -12894,7 +12895,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "rtp",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -12909,7 +12910,7 @@ dependencies = [
  "crc",
  "log",
  "rand 0.8.5",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "webrtc-util",
 ]
@@ -12933,7 +12934,7 @@ dependencies = [
  "rtp",
  "sha-1",
  "subtle",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "webrtc-util",
 ]
@@ -12954,7 +12955,7 @@ dependencies = [
  "log",
  "nix 0.24.3",
  "rand 0.8.5",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "tokio",
  "winapi",
 ]
@@ -13350,7 +13351,7 @@ dependencies = [
  "oid-registry 0.4.0",
  "ring 0.16.20",
  "rusticata-macros",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -13368,7 +13369,7 @@ dependencies = [
  "nom",
  "oid-registry 0.6.1",
  "rusticata-macros",
- "thiserror 1.0.60",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -13404,7 +13405,10 @@ name = "xor-fee"
 version = "0.1.0"
 dependencies = [
  "assets",
+ "ceres-liquidity-locker",
  "common",
+ "demeter-farming-platform",
+ "dex-manager",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -13418,6 +13422,9 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "permissions",
+ "pool-xyk",
+ "price-tools",
+ "pswap-distribution",
  "scale-info",
  "smallvec",
  "sp-arithmetic",
@@ -13426,6 +13433,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
+ "technical",
+ "trading-pair",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7753,6 +7753,7 @@ dependencies = [
  "assets",
  "common",
  "derivative",
+ "dex-manager",
  "frame-support",
  "frame-system",
  "orml-currencies",

--- a/common/src/primitives.rs
+++ b/common/src/primitives.rs
@@ -1292,6 +1292,39 @@ pub struct AssetInfo {
     pub description: Option<Description>,
 }
 
+#[derive(
+    Encode,
+    Decode,
+    Eq,
+    PartialEq,
+    Copy,
+    Clone,
+    PartialOrd,
+    Ord,
+    Debug,
+    Hash,
+    scale_info::TypeInfo,
+    MaxEncodedLen,
+)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct OrderBookId<AssetId, DEXId> {
+    /// DEX id
+    pub dex_id: DEXId,
+    /// Base asset.
+    pub base: AssetId,
+    /// Quote asset. It should be a base asset of DEX.
+    pub quote: AssetId,
+}
+
+impl<AssetId, DEXId> From<OrderBookId<AssetId, DEXId>> for TradingPair<AssetId> {
+    fn from(order_book_id: OrderBookId<AssetId, DEXId>) -> Self {
+        Self {
+            base_asset_id: order_book_id.quote,
+            target_asset_id: order_book_id.base,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -34,7 +34,7 @@ use crate::prelude::{
 use crate::{
     Amount, AssetId32, AssetName, AssetSymbol, AssetType, BalancePrecision, ContentSource,
     Description, Fixed, LiquiditySourceFilter, LiquiditySourceId, LiquiditySourceType, Oracle,
-    PredefinedAssetId, PriceVariant, PswapRemintInfo, RewardReason,
+    OrderBookId, PredefinedAssetId, PriceVariant, PswapRemintInfo, RewardReason,
 };
 
 use frame_support::dispatch::{DispatchResult, DispatchResultWithPostInfo};
@@ -1550,6 +1550,63 @@ impl<AccountId, AssetId> AssetRegulator<AccountId, AssetId> for () {
         _affected_account: &AccountId,
         _asset_id: &AssetId,
         _permission_id: &PermissionId,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+}
+
+/// Trait to manage and interact with order book
+pub trait OrderBookManager<AccountId, AssetId, DEXId, Moment> {
+    fn assemble_order_book_id(
+        dex_id: DEXId,
+        input_asset_id: &AssetId,
+        output_asset_id: &AssetId,
+    ) -> Option<OrderBookId<AssetId, DEXId>>;
+
+    fn initialize_orderbook(
+        order_book_id: &OrderBookId<AssetId, DEXId>,
+        tick_size: Balance,
+        step_lot_size: Balance,
+        min_lot_size: Balance,
+        max_lot_size: Balance,
+    ) -> Result<(), DispatchError>;
+
+    fn place_limit_order(
+        owner: AccountId,
+        order_book_id: OrderBookId<AssetId, DEXId>,
+        price: Balance,
+        amount: Balance,
+        side: PriceVariant,
+        lifespan: Option<Moment>,
+    ) -> Result<(), DispatchError>;
+}
+
+impl<AccountId, AssetId, DEXId, Moment> OrderBookManager<AccountId, AssetId, DEXId, Moment> for () {
+    fn assemble_order_book_id(
+        _dex_id: DEXId,
+        _input_asset_id: &AssetId,
+        _output_asset_id: &AssetId,
+    ) -> Option<OrderBookId<AssetId, DEXId>> {
+        None
+    }
+
+    fn initialize_orderbook(
+        _order_book_id: &OrderBookId<AssetId, DEXId>,
+        _tick_size: Balance,
+        _step_lot_size: Balance,
+        _min_lot_size: Balance,
+        _max_lot_size: Balance,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+
+    fn place_limit_order(
+        _owner: AccountId,
+        _order_book_id: OrderBookId<AssetId, DEXId>,
+        _price: Balance,
+        _amount: Balance,
+        _side: PriceVariant,
+        _lifespan: Option<Moment>,
     ) -> Result<(), DispatchError> {
         Ok(())
     }

--- a/pallets/liquidity-proxy/src/alt_test_utils.rs
+++ b/pallets/liquidity-proxy/src/alt_test_utils.rs
@@ -43,7 +43,7 @@ use qa_tools::pallet_tools::pool_xyk::AssetPairInput;
 use qa_tools::pallet_tools::price_tools::AssetPrices;
 use sp_std::vec;
 
-pub type OrderBookId = order_book::OrderBookId<AssetIdOf<Runtime>, DexIdOf<Runtime>>;
+pub type OrderBookId = common::OrderBookId<AssetIdOf<Runtime>, DexIdOf<Runtime>>;
 pub const DEX: common::DEXId = common::DEXId::Polkaswap;
 
 pub fn alice() -> AccountIdOf<Runtime> {

--- a/pallets/order-book/benchmarking/src/lib.rs
+++ b/pallets/order-book/benchmarking/src/lib.rs
@@ -57,10 +57,10 @@ use crate as order_book_benchmarking_imported;
 #[cfg(test)]
 use framenode_runtime::order_book_benchmarking as order_book_benchmarking_imported;
 
-use common::{AssetIdOf, DEXId};
+use common::{AssetIdOf, DEXId, OrderBookId};
 use frame_system::EventRecord;
 use order_book_imported::Pallet as OrderBookPallet;
-use order_book_imported::{LimitOrder, MomentOf, OrderBookId};
+use order_book_imported::{LimitOrder, MomentOf};
 
 mod periphery;
 #[cfg(test)]
@@ -148,8 +148,8 @@ mod benchmarks_inner {
     use order_book_imported::test_utils::fill_tools::{AmountVariant, FillSettings};
     use order_book_imported::test_utils::{accounts, create_and_fill_order_book};
     use order_book_imported::{
-        CancelReason, Event, ExpirationScheduler, MarketRole, OrderBook, OrderBookId,
-        OrderBookStatus, OrderPrice, OrderVolume,
+        CancelReason, Event, ExpirationScheduler, MarketRole, OrderBook, OrderBookStatus,
+        OrderPrice, OrderVolume,
     };
     use periphery::presets::*;
 

--- a/pallets/order-book/benchmarking/src/periphery/mod.rs
+++ b/pallets/order-book/benchmarking/src/periphery/mod.rs
@@ -45,7 +45,7 @@ use crate as order_book_benchmarking_imported;
 #[cfg(test)]
 use framenode_runtime::order_book_benchmarking as order_book_benchmarking_imported;
 
-use common::{AssetIdOf, AssetInfoProvider, PriceVariant, VAL, XOR};
+use common::{AssetIdOf, AssetInfoProvider, OrderBookId, PriceVariant, VAL, XOR};
 use frame_system::RawOrigin;
 use order_book_benchmarking_imported::Config;
 use order_book_imported::Pallet as OrderBookPallet;
@@ -55,7 +55,7 @@ use order_book_imported::{
         fill_tools::{AmountVariant, FillSettings},
     },
     CancelReason, Event, LimitOrder, LimitOrders, MarketRole, MomentOf, OrderAmount, OrderBook,
-    OrderBookId, OrderBookStatus, OrderBooks, OrderPrice, OrderVolume,
+    OrderBookStatus, OrderBooks, OrderPrice, OrderVolume,
 };
 
 use crate::{assert_last_event, assert_orders_numbers, DEX};

--- a/pallets/order-book/benchmarking/src/periphery/preparation.rs
+++ b/pallets/order-book/benchmarking/src/periphery/preparation.rs
@@ -43,7 +43,7 @@ use crate as order_book_benchmarking_imported;
 use framenode_runtime::order_book_benchmarking as order_book_benchmarking_imported;
 
 use common::prelude::{QuoteAmount, Scalar};
-use common::{balance, AssetIdOf, AssetManager, Balance, PriceVariant, ETH, VAL, XOR};
+use common::{balance, AssetIdOf, AssetManager, Balance, OrderBookId, PriceVariant, ETH, VAL, XOR};
 use frame_benchmarking::log::debug;
 use frame_support::traits::Time;
 use frame_system::RawOrigin;
@@ -55,7 +55,7 @@ use order_book_imported::test_utils::fill_tools::{
 };
 use order_book_imported::{
     cache_data_layer::CacheDataLayer, traits::DataLayer, DealInfo, LimitOrder, MomentOf, OrderBook,
-    OrderBookId, OrderBooks, OrderPrice, OrderVolume,
+    OrderBooks, OrderPrice, OrderVolume,
 };
 use sp_runtime::traits::{CheckedMul, SaturatedConversion};
 use sp_std::iter::Peekable;

--- a/pallets/order-book/src/cache_data_layer.rs
+++ b/pallets/order-book/src/cache_data_layer.rs
@@ -30,11 +30,10 @@
 
 use crate::{
     AggregatedAsks, AggregatedBids, Asks, Bids, Config, DataLayer, Error, LimitOrder, LimitOrders,
-    MarketSide, OrderBookId, OrderPrice, OrderVolume, PriceOrders, UserLimitOrders, UserOrders,
+    MarketSide, OrderPrice, OrderVolume, PriceOrders, UserLimitOrders, UserOrders,
 };
 use common::cache_storage::{CacheStorageDoubleMap, CacheStorageMap};
-use common::AssetIdOf;
-use common::PriceVariant;
+use common::{AssetIdOf, OrderBookId, PriceVariant};
 use frame_support::ensure;
 use frame_support::sp_runtime::DispatchError;
 use frame_support::traits::Len;

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -1348,9 +1348,9 @@ impl<T: Config> Pallet<T> {
         min_lot_size: Balance,
         max_lot_size: Balance,
     ) -> Result<(), DispatchError> {
-        Self::verify_create_orderbook_params(&order_book_id)?;
+        Self::verify_create_orderbook_params(order_book_id)?;
         Self::verify_orderbook_attributes(
-            &order_book_id,
+            order_book_id,
             tick_size,
             step_lot_size,
             min_lot_size,
@@ -1365,7 +1365,7 @@ impl<T: Config> Pallet<T> {
         )?;
 
         Self::create_orderbook_unchecked(
-            &order_book_id,
+            order_book_id,
             tick_size,
             step_lot_size,
             min_lot_size,

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -42,7 +42,7 @@ use common::AssetIdOf;
 use common::LiquiditySourceType;
 use common::{
     AssetInfoProvider, AssetName, AssetSymbol, Balance, BalancePrecision, ContentSource,
-    Description, DexInfoProvider, LiquiditySource, PriceVariant, RewardReason,
+    Description, DexInfoProvider, LiquiditySource, OrderBookId, PriceVariant, RewardReason,
     SyntheticInfoProvider, ToOrderTechUnitFromDEXAndTradingPair, TradingPairSourceManager,
 };
 use core::fmt::Debug;
@@ -86,8 +86,8 @@ pub use traits::{
 };
 pub use types::{
     CancelReason, DealInfo, MarketChange, MarketRole, MarketSide, OrderAmount, OrderBookEvent,
-    OrderBookId, OrderBookStatus, OrderBookTechStatus, OrderPrice, OrderVolume, Payment,
-    PriceOrders, UserOrders,
+    OrderBookStatus, OrderBookTechStatus, OrderPrice, OrderVolume, Payment, PriceOrders,
+    UserOrders,
 };
 pub use weights::WeightInfo;
 

--- a/pallets/order-book/src/lib.rs
+++ b/pallets/order-book/src/lib.rs
@@ -594,8 +594,7 @@ pub mod pallet {
                 Either::Right(()) => None,
             };
 
-            Self::verify_create_orderbook_params(&order_book_id)?;
-            Self::verify_orderbook_attributes(
+            Self::inner_create_orderbook(
                 &order_book_id,
                 tick_size,
                 step_lot_size,
@@ -603,20 +602,6 @@ pub mod pallet {
                 max_lot_size,
             )?;
 
-            T::TradingPairSourceManager::enable_source_for_trading_pair(
-                &order_book_id.dex_id,
-                &order_book_id.quote,
-                &order_book_id.base,
-                LiquiditySourceType::OrderBook,
-            )?;
-
-            Self::create_orderbook_unchecked(
-                &order_book_id,
-                tick_size,
-                step_lot_size,
-                min_lot_size,
-                max_lot_size,
-            )?;
             Self::deposit_event(Event::<T>::OrderBookCreated {
                 order_book_id,
                 creator: maybe_who,
@@ -1379,6 +1364,38 @@ impl<T: Config> Pallet<T> {
         };
         <OrderBooks<T>>::insert(order_book_id, order_book);
         Self::register_tech_account(*order_book_id)
+    }
+
+    pub fn inner_create_orderbook(
+        order_book_id: &OrderBookId<AssetIdOf<T>, T::DEXId>,
+        tick_size: Balance,
+        step_lot_size: Balance,
+        min_lot_size: Balance,
+        max_lot_size: Balance,
+    ) -> Result<(), DispatchError> {
+        Self::verify_create_orderbook_params(&order_book_id)?;
+        Self::verify_orderbook_attributes(
+            &order_book_id,
+            tick_size,
+            step_lot_size,
+            min_lot_size,
+            max_lot_size,
+        )?;
+
+        T::TradingPairSourceManager::enable_source_for_trading_pair(
+            &order_book_id.dex_id,
+            &order_book_id.quote,
+            &order_book_id.base,
+            LiquiditySourceType::OrderBook,
+        )?;
+
+        Self::create_orderbook_unchecked(
+            &order_book_id,
+            tick_size,
+            step_lot_size,
+            min_lot_size,
+            max_lot_size,
+        )
     }
 }
 

--- a/pallets/order-book/src/market_order.rs
+++ b/pallets/order-book/src/market_order.rs
@@ -28,10 +28,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{Error, OrderBookId, OrderVolume};
+use crate::{Error, OrderVolume};
 use codec::{Decode, Encode, MaxEncodedLen};
-use common::AssetIdOf;
-use common::PriceVariant;
+use common::{AssetIdOf, OrderBookId, PriceVariant};
 use core::fmt::Debug;
 use frame_support::ensure;
 use frame_support::sp_runtime::DispatchError;

--- a/pallets/order-book/src/order_book.rs
+++ b/pallets/order-book/src/order_book.rs
@@ -30,13 +30,12 @@
 
 use crate::{
     CancelReason, DataLayer, DealInfo, Delegate, Error, ExpirationScheduler, LimitOrder,
-    MarketChange, MarketOrder, MarketRole, OrderAmount, OrderBookEvent, OrderBookId,
-    OrderBookStatus, OrderBookTechStatus, OrderPrice, OrderVolume, Payment,
+    MarketChange, MarketOrder, MarketRole, OrderAmount, OrderBookEvent, OrderBookStatus,
+    OrderBookTechStatus, OrderPrice, OrderVolume, Payment,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use common::prelude::QuoteAmount;
-use common::AssetIdOf;
-use common::{Balance, PriceVariant};
+use common::{AssetIdOf, Balance, OrderBookId, PriceVariant};
 use frame_support::ensure;
 use frame_support::sp_runtime::DispatchError;
 use frame_support::traits::Get;

--- a/pallets/order-book/src/scheduler.rs
+++ b/pallets/order-book/src/scheduler.rs
@@ -38,11 +38,10 @@ use crate::traits::{AlignmentScheduler, ExpirationScheduler};
 use crate::weights::WeightInfo;
 use crate::{
     AlignmentCursor, CacheDataLayer, Config, DataLayer, Error, Event, ExpirationsAgenda,
-    IncompleteExpirationsSince, LimitOrder, LimitOrders, OrderBookId, OrderBookTechStatus,
-    OrderBooks, Pallet,
+    IncompleteExpirationsSince, LimitOrder, LimitOrders, OrderBookTechStatus, OrderBooks, Pallet,
 };
 use common::weights::check_accrue_n;
-use common::AssetIdOf;
+use common::{AssetIdOf, OrderBookId};
 use frame_support::weights::WeightMeter;
 use sp_runtime::traits::{One, Zero};
 use sp_runtime::{DispatchError, Saturating};

--- a/pallets/order-book/src/storage_data_layer.rs
+++ b/pallets/order-book/src/storage_data_layer.rs
@@ -30,11 +30,10 @@
 
 use crate::{
     AggregatedAsks, AggregatedBids, Asks, Bids, Config, DataLayer, Error, LimitOrder, LimitOrders,
-    MarketSide, OrderBookId, OrderPrice, OrderVolume, PriceOrders, UserLimitOrders, UserOrders,
+    MarketSide, OrderPrice, OrderVolume, PriceOrders, UserLimitOrders, UserOrders,
 };
 use common::storage::DecodeIsFullDoubleMap;
-use common::AssetIdOf;
-use common::PriceVariant;
+use common::{AssetIdOf, OrderBookId, PriceVariant};
 use frame_support::ensure;
 use frame_support::sp_runtime::DispatchError;
 use sp_runtime::traits::{CheckedAdd, CheckedSub, Zero};

--- a/pallets/order-book/src/test_utils/fill_tools.rs
+++ b/pallets/order-book/src/test_utils/fill_tools.rs
@@ -32,13 +32,12 @@
 
 use super::{accounts, order_book_imported};
 use order_book_imported::{
-    traits::DataLayer, Config, ExpirationsAgenda, LimitOrder, MarketRole, OrderBook, OrderBookId,
-    OrderPrice, OrderVolume, Pallet, Payment,
+    traits::DataLayer, Config, ExpirationsAgenda, LimitOrder, MarketRole, OrderBook, OrderPrice,
+    OrderVolume, Pallet, Payment,
 };
 
 use common::prelude::{Balance, BalanceUnit, Scalar};
-use common::PriceVariant;
-use common::{AssetIdOf, AssetManager};
+use common::{AssetIdOf, AssetManager, OrderBookId, PriceVariant};
 use frame_support::log::{debug, trace};
 use frame_support::traits::{Get, Time};
 use sp_runtime::traits::{CheckedMul, SaturatedConversion};

--- a/pallets/order-book/src/test_utils/mod.rs
+++ b/pallets/order-book/src/test_utils/mod.rs
@@ -35,12 +35,14 @@ use crate as order_book_imported;
 use framenode_runtime::order_book as order_book_imported;
 
 use order_book_imported::{
-    Config, OrderBook, OrderBookId, OrderBookStatus, OrderBookTechStatus, OrderPrice, OrderVolume,
-    Pallet, PriceOrders,
+    Config, OrderBook, OrderBookStatus, OrderBookTechStatus, OrderPrice, OrderVolume, Pallet,
+    PriceOrders,
 };
 
-use common::AssetIdOf;
-use common::{balance, AssetInfoProvider, AssetManager, Balance, DexIdOf, PriceVariant};
+use common::{
+    balance, AssetIdOf, AssetInfoProvider, AssetManager, Balance, DexIdOf, OrderBookId,
+    PriceVariant,
+};
 use frame_support::assert_ok;
 use frame_support::dispatch::DispatchResult;
 use frame_system::RawOrigin;

--- a/pallets/order-book/src/test_utils/print_tools.rs
+++ b/pallets/order-book/src/test_utils/print_tools.rs
@@ -31,11 +31,10 @@
 use super::order_book_imported;
 
 use common::prelude::FixedWrapper;
-use common::AssetIdOf;
-use common::PriceVariant;
+use common::{AssetIdOf, OrderBookId, PriceVariant};
 use order_book_imported::{
-    Asks, Bids, Config, ExpirationsAgenda, LimitOrder, LimitOrders, OrderBookId, OrderPrice,
-    OrderVolume, PriceOrders,
+    Asks, Bids, Config, ExpirationsAgenda, LimitOrder, LimitOrders, OrderPrice, OrderVolume,
+    PriceOrders,
 };
 use sp_runtime::traits::{CheckedAdd, Zero};
 use sp_runtime::BoundedVec;

--- a/pallets/order-book/src/tests/data_layer.rs
+++ b/pallets/order-book/src/tests/data_layer.rs
@@ -31,13 +31,13 @@
 use crate::test_utils::*;
 use assets::AssetIdOf;
 use common::prelude::BalanceUnit;
-use common::{balance, PriceVariant, ETH, PSWAP, VAL, XOR};
+use common::{balance, OrderBookId, PriceVariant, ETH, PSWAP, VAL, XOR};
 use frame_support::{assert_err, assert_ok};
 use framenode_chain_spec::ext;
 use framenode_runtime::order_book::cache_data_layer::CacheDataLayer;
 use framenode_runtime::order_book::storage_data_layer::StorageDataLayer;
 use framenode_runtime::order_book::{
-    Config, DataLayer, LimitOrder, OrderBook, OrderBookId, OrderBooks, OrderPrice,
+    Config, DataLayer, LimitOrder, OrderBook, OrderBooks, OrderPrice,
 };
 use framenode_runtime::Runtime;
 use sp_core::Get;

--- a/pallets/order-book/src/tests/extrinsics.rs
+++ b/pallets/order-book/src/tests/extrinsics.rs
@@ -33,16 +33,16 @@ use assets::AssetIdOf;
 #[cfg(feature = "wip")] // presto
 use common::PRUSD;
 use common::{
-    balance, AssetId32, AssetName, AssetSymbol, Balance, PriceVariant, DEFAULT_BALANCE_PRECISION,
-    ETH, KUSD, PSWAP, VAL, VXOR, XOR, XST, XSTUSD,
+    balance, AssetId32, AssetName, AssetSymbol, Balance, OrderBookId, PriceVariant,
+    DEFAULT_BALANCE_PRECISION, ETH, KUSD, PSWAP, VAL, VXOR, XOR, XST, XSTUSD,
 };
 use frame_support::error::BadOrigin;
 use frame_support::{assert_err, assert_ok};
 use frame_system::RawOrigin;
 use framenode_chain_spec::ext;
 use framenode_runtime::order_book::{
-    Config, LimitOrder, LimitOrders, MarketRole, OrderBook, OrderBookId, OrderBookStatus,
-    OrderBookTechStatus, OrderPrice, OrderVolume,
+    Config, LimitOrder, LimitOrders, MarketRole, OrderBook, OrderBookStatus, OrderBookTechStatus,
+    OrderPrice, OrderVolume,
 };
 use framenode_runtime::{Runtime, RuntimeOrigin};
 use hex_literal::hex;

--- a/pallets/order-book/src/tests/order_book.rs
+++ b/pallets/order-book/src/tests/order_book.rs
@@ -31,15 +31,14 @@
 use crate::test_utils::*;
 use assets::AssetIdOf;
 use common::prelude::QuoteAmount;
-use common::{balance, AssetName, AssetSymbol, PriceVariant, DOT, KSM, VAL, XOR};
+use common::{balance, AssetName, AssetSymbol, OrderBookId, PriceVariant, DOT, KSM, VAL, XOR};
 use frame_support::{assert_err, assert_ok};
 use framenode_chain_spec::ext;
 use framenode_runtime::order_book::cache_data_layer::CacheDataLayer;
 use framenode_runtime::order_book::storage_data_layer::StorageDataLayer;
 use framenode_runtime::order_book::{
     CancelReason, Config, DataLayer, DealInfo, LimitOrder, MarketChange, MarketOrder, MarketRole,
-    OrderAmount, OrderBook, OrderBookId, OrderBookStatus, OrderBookTechStatus, OrderPrice,
-    OrderVolume, Payment,
+    OrderAmount, OrderBook, OrderBookStatus, OrderBookTechStatus, OrderPrice, OrderVolume, Payment,
 };
 use framenode_runtime::{Runtime, RuntimeOrigin};
 use sp_core::Get;

--- a/pallets/order-book/src/tests/orders.rs
+++ b/pallets/order-book/src/tests/orders.rs
@@ -30,11 +30,9 @@
 
 use crate::test_utils::*;
 use assets::AssetIdOf;
-use common::{balance, PriceVariant, VAL, XOR};
+use common::{balance, OrderBookId, PriceVariant, VAL, XOR};
 use frame_support::{assert_err, assert_ok};
-use framenode_runtime::order_book::{
-    Config, LimitOrder, MarketOrder, MarketRole, OrderAmount, OrderBookId,
-};
+use framenode_runtime::order_book::{Config, LimitOrder, MarketOrder, MarketRole, OrderAmount};
 use framenode_runtime::Runtime;
 
 #[test]

--- a/pallets/order-book/src/tests/pallet.rs
+++ b/pallets/order-book/src/tests/pallet.rs
@@ -33,7 +33,8 @@ use assets::AssetIdOf;
 use common::alt::{DiscreteQuotation, SideAmount, SwapChunk, SwapLimits};
 use common::prelude::{QuoteAmount, SwapAmount, SwapOutcome};
 use common::{
-    balance, AssetName, AssetSymbol, Balance, LiquiditySource, PriceVariant, VAL, XOR, XSTUSD,
+    balance, AssetName, AssetSymbol, Balance, LiquiditySource, OrderBookId, PriceVariant, VAL, XOR,
+    XSTUSD,
 };
 use core::cmp::min;
 use frame_support::traits::Get;
@@ -42,7 +43,7 @@ use frame_system::RawOrigin;
 use framenode_chain_spec::ext;
 use framenode_runtime::order_book::{
     self, Config, CurrencyLocker, CurrencyUnlocker, ExpirationScheduler, LimitOrder, MarketRole,
-    OrderBook, OrderBookId, OrderBookStatus, OrderPrice, OrderVolume, WeightInfo,
+    OrderBook, OrderBookStatus, OrderPrice, OrderVolume, WeightInfo,
 };
 use framenode_runtime::{Runtime, RuntimeOrigin};
 use sp_runtime::traits::UniqueSaturatedInto;

--- a/pallets/order-book/src/tests/types.rs
+++ b/pallets/order-book/src/tests/types.rs
@@ -30,12 +30,11 @@
 
 use crate::test_utils::*;
 use assets::AssetIdOf;
-use common::{balance, PriceVariant, DAI, VAL, XOR};
+use common::{balance, OrderBookId, PriceVariant, DAI, VAL, XOR};
 use frame_support::assert_ok;
 use framenode_chain_spec::ext;
 use framenode_runtime::order_book::{
-    CancelReason, Config, DealInfo, LimitOrder, MarketChange, OrderAmount, OrderBookId,
-    OrderVolume, Payment,
+    CancelReason, Config, DealInfo, LimitOrder, MarketChange, OrderAmount, OrderVolume, Payment,
 };
 use framenode_runtime::Runtime;
 use sp_std::collections::btree_map::BTreeMap;

--- a/pallets/order-book/src/traits.rs
+++ b/pallets/order-book/src/traits.rs
@@ -29,11 +29,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    Config, LimitOrder, MarketSide, OrderBookEvent, OrderBookId, OrderPrice, OrderVolume,
-    PriceOrders, UserOrders,
+    Config, LimitOrder, MarketSide, OrderBookEvent, OrderPrice, OrderVolume, PriceOrders,
+    UserOrders,
 };
-use common::AssetIdOf;
-use common::PriceVariant;
+use common::{AssetIdOf, OrderBookId, PriceVariant};
 use frame_support::sp_runtime::DispatchError;
 use frame_support::weights::WeightMeter;
 use sp_std::collections::btree_map::BTreeMap;

--- a/pallets/order-book/src/types.rs
+++ b/pallets/order-book/src/types.rs
@@ -31,7 +31,7 @@
 use crate::traits::{CurrencyLocker, CurrencyUnlocker};
 use codec::{Decode, Encode, MaxEncodedLen};
 use common::prelude::BalanceUnit;
-use common::{PriceVariant, TradingPair};
+use common::{OrderBookId, PriceVariant};
 use frame_support::sp_runtime::DispatchError;
 use frame_support::{BoundedBTreeMap, BoundedVec};
 use sp_runtime::traits::{CheckedAdd, CheckedDiv, CheckedSub, Saturating, Zero};
@@ -187,39 +187,6 @@ impl Sub for OrderAmount {
 pub enum MarketRole {
     Maker,
     Taker,
-}
-
-#[derive(
-    Encode,
-    Decode,
-    Eq,
-    PartialEq,
-    Copy,
-    Clone,
-    PartialOrd,
-    Ord,
-    Debug,
-    Hash,
-    scale_info::TypeInfo,
-    MaxEncodedLen,
-)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct OrderBookId<AssetId, DEXId> {
-    /// DEX id
-    pub dex_id: DEXId,
-    /// Base asset.
-    pub base: AssetId,
-    /// Quote asset. It should be a base asset of DEX.
-    pub quote: AssetId,
-}
-
-impl<AssetId, DEXId> From<OrderBookId<AssetId, DEXId>> for TradingPair<AssetId> {
-    fn from(order_book_id: OrderBookId<AssetId, DEXId>) -> Self {
-        Self {
-            base_asset_id: order_book_id.quote,
-            target_asset_id: order_book_id.base,
-        }
-    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/pallets/presto/Cargo.toml
+++ b/pallets/presto/Cargo.toml
@@ -33,6 +33,7 @@ pallet-timestamp = { git = "https://github.com/sora-xor/substrate.git", branch =
 permissions = { path = "../permissions" }
 sp-io = { git = "https://github.com/sora-xor/substrate.git", branch = "polkadot-v0.9.38" }
 tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", package = "orml-tokens", default-features = false }
+trading-pair = { path = "../trading-pair", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/presto/Cargo.toml
+++ b/pallets/presto/Cargo.toml
@@ -28,6 +28,7 @@ technical = { path = "../technical", default-features = false }
 common = { path = "../../common", features = ["test"] }
 assets = { path = "../assets", default-features = false }
 currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", package = "orml-currencies", default-features = false }
+dex-manager = { path = "../dex-manager", default-features = false }
 pallet-balances = { git = "https://github.com/sora-xor/substrate.git", branch = "polkadot-v0.9.38", default-features = false }
 pallet-timestamp = { git = "https://github.com/sora-xor/substrate.git", branch = "polkadot-v0.9.38", default-features = false }
 permissions = { path = "../permissions" }
@@ -42,6 +43,7 @@ std = [
     "common/std",
     "codec/std",
     "currencies/std",
+    "dex-manager/std",
     "frame-support/std",
     "frame-system/std",
     "pallet-balances/std",

--- a/pallets/presto/Cargo.toml
+++ b/pallets/presto/Cargo.toml
@@ -29,6 +29,7 @@ common = { path = "../../common", features = ["test"] }
 assets = { path = "../assets", default-features = false }
 currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library.git", package = "orml-currencies", default-features = false }
 dex-manager = { path = "../dex-manager", default-features = false }
+order-book = { path = "../order-book", default-features = false }
 pallet-balances = { git = "https://github.com/sora-xor/substrate.git", branch = "polkadot-v0.9.38", default-features = false }
 pallet-timestamp = { git = "https://github.com/sora-xor/substrate.git", branch = "polkadot-v0.9.38", default-features = false }
 permissions = { path = "../permissions" }

--- a/pallets/presto/src/lib.rs
+++ b/pallets/presto/src/lib.rs
@@ -64,7 +64,7 @@ pub mod pallet {
     use super::*;
     use common::{
         AssetIdOf, AssetManager, AssetName, AssetSymbol, AssetType, Balance, BoundedString, DEXId,
-        TradingPairSourceManager, PRUSD,
+        OrderBookManager, TradingPairSourceManager, PRUSD,
     };
     use core::fmt::Debug;
     use core::str::FromStr;
@@ -89,6 +89,12 @@ pub mod pallet {
     pub trait Config: frame_system::Config + common::Config + technical::Config {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         type TradingPairSourceManager: TradingPairSourceManager<Self::DEXId, AssetIdOf<Self>>;
+        type OrderBookManager: OrderBookManager<
+            AccountIdOf<Self>,
+            AssetIdOf<Self>,
+            Self::DEXId,
+            MomentOf<Self>,
+        >;
         type PrestoUsdAssetId: Get<AssetIdOf<Self>>;
         type PrestoTechAccount: Get<Self::TechAccountId>;
         type PrestoBufferTechAccount: Get<Self::TechAccountId>;

--- a/pallets/presto/src/mock.rs
+++ b/pallets/presto/src/mock.rs
@@ -114,11 +114,13 @@ parameter_types! {
 
 impl presto::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type TradingPairSourceManager = trading_pair::Pallet<Runtime>;
     type PrestoUsdAssetId = PrestoUsdAssetId;
     type PrestoTechAccount = PrestoTechAccountId;
     type PrestoBufferTechAccount = PrestoBufferTechAccountId;
     type RequestId = u64;
     type CropReceiptId = u64;
+    type CouponId = u64;
     type MaxPrestoManagersCount = ConstU32<100>;
     type MaxPrestoAuditorsCount = ConstU32<100>;
     type MaxUserRequestCount = ConstU32<65536>;

--- a/pallets/presto/src/mock.rs
+++ b/pallets/presto/src/mock.rs
@@ -34,11 +34,11 @@ use crate as presto;
 
 use common::mock::ExistentialDeposits;
 use common::{
-    mock_assets_config, mock_common_config, mock_currencies_config, mock_frame_system_config,
-    mock_pallet_balances_config, mock_pallet_timestamp_config, mock_permissions_config,
-    mock_technical_config, mock_tokens_config, Amount, AssetId32, AssetName, AssetSymbol,
-    BoundedString, DEXId, FromGenericPair, PredefinedAssetId, DEFAULT_BALANCE_PRECISION, KUSD,
-    PRUSD, XOR,
+    mock_assets_config, mock_common_config, mock_currencies_config, mock_dex_manager_config,
+    mock_frame_system_config, mock_pallet_balances_config, mock_pallet_timestamp_config,
+    mock_permissions_config, mock_technical_config, mock_tokens_config, mock_trading_pair_config,
+    Amount, AssetId32, AssetName, AssetSymbol, BoundedString, DEXId, FromGenericPair,
+    PredefinedAssetId, DEFAULT_BALANCE_PRECISION, KUSD, PRUSD, XOR,
 };
 use currencies::BasicCurrencyAdapter;
 use frame_support::traits::{ConstU32, GenesisBuild};
@@ -67,7 +67,9 @@ construct_runtime! {
         Currencies: currencies::{Pallet, Call, Storage},
         Assets: assets::{Pallet, Call, Config<T>, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
+        DexManager: dex_manager::{Pallet, Call, Config<T>, Storage},
         Technical: technical::{Pallet, Call, Config<T>, Storage, Event<T>},
+        TradingPair: trading_pair::{Pallet, Call, Config<T>, Storage, Event<T>},
         Permissions: permissions::{Pallet, Call, Config<T>, Storage, Event<T>},
         Presto: presto::{Pallet, Call, Storage, Event<T>},
     }
@@ -81,12 +83,14 @@ parameter_types! {
 mock_common_config!(Runtime);
 mock_assets_config!(Runtime);
 mock_currencies_config!(Runtime);
+mock_dex_manager_config!(Runtime);
 mock_tokens_config!(Runtime);
 mock_pallet_balances_config!(Runtime);
 mock_frame_system_config!(Runtime);
 mock_technical_config!(Runtime);
 mock_pallet_timestamp_config!(Runtime);
 mock_permissions_config!(Runtime);
+mock_trading_pair_config!(Runtime);
 
 parameter_types! {
     pub const PrestoUsdAssetId: AssetId = PRUSD;

--- a/pallets/presto/src/mock.rs
+++ b/pallets/presto/src/mock.rs
@@ -41,8 +41,9 @@ use common::{
     PredefinedAssetId, DEFAULT_BALANCE_PRECISION, KUSD, PRUSD, XOR,
 };
 use currencies::BasicCurrencyAdapter;
-use frame_support::traits::{ConstU32, GenesisBuild};
+use frame_support::traits::{ConstU32, EitherOfDiverse, GenesisBuild};
 use frame_support::{construct_runtime, parameter_types};
+use frame_system::{EnsureRoot, EnsureSigned};
 use permissions::Scope;
 use sp_runtime::AccountId32;
 
@@ -54,6 +55,13 @@ pub type TechAccountId = common::TechAccountId<AccountId, TechAssetId, DEXId>;
 type TechAssetId = common::TechAssetId<PredefinedAssetId>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Moment = u64;
+
+pub const MILLISECS_PER_BLOCK: Moment = 6000;
+pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
+pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
+pub const HOURS: BlockNumber = MINUTES * 60;
+pub const DAYS: BlockNumber = HOURS * 24;
 
 construct_runtime! {
     pub enum Runtime where
@@ -68,8 +76,9 @@ construct_runtime! {
         Assets: assets::{Pallet, Call, Config<T>, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
         DexManager: dex_manager::{Pallet, Call, Config<T>, Storage},
+        OrderBook: order_book::{Pallet, Call, Storage, Event<T>},
         Technical: technical::{Pallet, Call, Config<T>, Storage, Event<T>},
-        TradingPair: trading_pair::{Pallet, Call, Config<T>, Storage, Event<T>},
+        TradingPair: trading_pair::{Pallet, Call, Storage, Event<T>},
         Permissions: permissions::{Pallet, Call, Config<T>, Storage, Event<T>},
         Presto: presto::{Pallet, Call, Storage, Event<T>},
     }
@@ -91,6 +100,36 @@ mock_technical_config!(Runtime);
 mock_pallet_timestamp_config!(Runtime);
 mock_permissions_config!(Runtime);
 mock_trading_pair_config!(Runtime);
+
+impl order_book::Config for Runtime {
+    const MAX_ORDER_LIFESPAN: Moment = 30 * (DAYS as Moment) * MILLISECS_PER_BLOCK; // 30 days = 2_592_000_000
+    const MIN_ORDER_LIFESPAN: Moment = (MINUTES as Moment) * MILLISECS_PER_BLOCK; // 1 minute = 60_000
+    const MILLISECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK;
+    const SOFT_MIN_MAX_RATIO: usize = 1000;
+    const HARD_MIN_MAX_RATIO: usize = 4000;
+    const REGULAR_NUBMER_OF_EXECUTED_ORDERS: usize = 100;
+    type RuntimeEvent = RuntimeEvent;
+    type OrderId = u128;
+    type Locker = order_book::Pallet<Runtime>;
+    type Unlocker = order_book::Pallet<Runtime>;
+    type Scheduler = order_book::Pallet<Runtime>;
+    type Delegate = order_book::Pallet<Runtime>;
+    type MaxOpenedLimitOrdersPerUser = ConstU32<1024>;
+    type MaxLimitOrdersForPrice = ConstU32<1024>;
+    type MaxSidePriceCount = ConstU32<1024>;
+    type MaxExpiringOrdersPerBlock = ConstU32<1024>;
+    type MaxExpirationWeightPerBlock = ();
+    type MaxAlignmentWeightPerBlock = ();
+    type EnsureTradingPairExists = trading_pair::Pallet<Runtime>;
+    type TradingPairSourceManager = trading_pair::Pallet<Runtime>;
+    type AssetInfoProvider = assets::Pallet<Runtime>;
+    type SyntheticInfoProvider = ();
+    type DexInfoProvider = dex_manager::Pallet<Runtime>;
+    type Time = Timestamp;
+    type PermittedCreateOrigin = EitherOfDiverse<EnsureSigned<AccountId>, EnsureRoot<AccountId>>;
+    type PermittedEditOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
 
 parameter_types! {
     pub const PrestoUsdAssetId: AssetId = PRUSD;
@@ -119,6 +158,7 @@ parameter_types! {
 impl presto::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type TradingPairSourceManager = trading_pair::Pallet<Runtime>;
+    type OrderBookManager = order_book::Pallet<Runtime>;
     type PrestoUsdAssetId = PrestoUsdAssetId;
     type PrestoTechAccount = PrestoTechAccountId;
     type PrestoBufferTechAccount = PrestoBufferTechAccountId;

--- a/pallets/presto/src/mock.rs
+++ b/pallets/presto/src/mock.rs
@@ -37,8 +37,8 @@ use common::{
     mock_assets_config, mock_common_config, mock_currencies_config, mock_dex_manager_config,
     mock_frame_system_config, mock_pallet_balances_config, mock_pallet_timestamp_config,
     mock_permissions_config, mock_technical_config, mock_tokens_config, mock_trading_pair_config,
-    Amount, AssetId32, AssetName, AssetSymbol, BoundedString, DEXId, FromGenericPair,
-    PredefinedAssetId, DEFAULT_BALANCE_PRECISION, KUSD, PRUSD, XOR,
+    Amount, AssetId32, AssetName, AssetSymbol, BoundedString, DEXId, DEXInfo, FromGenericPair,
+    PredefinedAssetId, DEFAULT_BALANCE_PRECISION, KUSD, PRUSD, XOR, XST,
 };
 use currencies::BasicCurrencyAdapter;
 use frame_support::traits::{ConstU32, EitherOfDiverse, GenesisBuild};
@@ -253,6 +253,29 @@ pub fn ext() -> sp_io::TestExternalities {
                 true,
                 None,
                 None,
+            ),
+        ],
+    }
+    .assimilate_storage(&mut storage)
+    .unwrap();
+
+    DexManagerConfig {
+        dex_list: vec![
+            (
+                DEXId::Polkaswap,
+                DEXInfo {
+                    base_asset_id: XOR,
+                    synthetic_base_asset_id: XST,
+                    is_public: true,
+                },
+            ),
+            (
+                DEXId::PolkaswapPresto,
+                DEXInfo {
+                    base_asset_id: PRUSD,
+                    synthetic_base_asset_id: XST,
+                    is_public: true,
+                },
             ),
         ],
     }

--- a/pallets/qa-tools/src/lib.rs
+++ b/pallets/qa-tools/src/lib.rs
@@ -58,13 +58,13 @@ pub mod pallet {
 
     use common::{
         AccountIdOf, AssetIdOf, AssetInfoProvider, AssetName, AssetSymbol, BalancePrecision,
-        ContentSource, DEXInfo, Description, DexIdOf, DexInfoProvider, SyntheticInfoProvider,
-        TradingPairSourceManager,
+        ContentSource, DEXInfo, Description, DexIdOf, DexInfoProvider, OrderBookId,
+        SyntheticInfoProvider, TradingPairSourceManager,
     };
     use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
-    use order_book::{MomentOf, OrderBookId};
+    use order_book::MomentOf;
     use pallet_tools::liquidity_proxy::liquidity_sources;
     use pallet_tools::pool_xyk::AssetPairInput;
     use pallet_tools::xst::{BaseInput, SyntheticInput, SyntheticOutput};

--- a/pallets/qa-tools/src/pallet_tools/liquidity_proxy.rs
+++ b/pallets/qa-tools/src/pallet_tools/liquidity_proxy.rs
@@ -34,11 +34,11 @@ pub mod liquidity_sources {
     use crate::pallet_tools::mcbc::TbcdCollateralInput;
     use crate::pallet_tools::price_tools::AssetPrices;
     use crate::Config;
-    use common::{AssetIdOf, DexIdOf};
+    use common::{AssetIdOf, DexIdOf, OrderBookId};
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use frame_support::ensure;
     use frame_system::pallet_prelude::BlockNumberFor;
-    use order_book::{MomentOf, OrderBookId};
+    use order_book::MomentOf;
     use pallet_tools::mcbc::{BaseSupply, OtherCollateralInput};
     use pallet_tools::pool_xyk::AssetPairInput;
     use pallet_tools::xst::{BaseInput, SyntheticInput, SyntheticOutput};

--- a/pallets/qa-tools/src/pallet_tools/order_book.rs
+++ b/pallets/qa-tools/src/pallet_tools/order_book.rs
@@ -30,12 +30,14 @@
 
 use crate::Config;
 use codec::{Decode, Encode};
-use common::{balance, AssetIdOf, AssetManager, Balance, PriceVariant, TradingPairSourceManager};
+use common::{
+    balance, AssetIdOf, AssetManager, Balance, OrderBookId, PriceVariant, TradingPairSourceManager,
+};
 use frame_support::pallet_prelude::*;
 use frame_support::traits::Time;
 use frame_system::pallet_prelude::*;
 use order_book::DataLayer;
-use order_book::{MomentOf, OrderBook, OrderBookId, OrderPrice, OrderVolume};
+use order_book::{MomentOf, OrderBook, OrderPrice, OrderVolume};
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sp_std::iter::repeat;

--- a/pallets/qa-tools/src/tests/order_book.rs
+++ b/pallets/qa-tools/src/tests/order_book.rs
@@ -31,8 +31,8 @@
 use super::{alice, bob, charlie, dave, FrameSystem, QaToolsPallet};
 use assets::AssetIdOf;
 use common::{
-    balance, AssetId32, AssetName, AssetSymbol, Balance, DEXId, DexIdOf, PredefinedAssetId,
-    PriceVariant, PSWAP, VAL, XOR,
+    balance, AssetId32, AssetName, AssetSymbol, Balance, DEXId, DexIdOf, OrderBookId,
+    PredefinedAssetId, PriceVariant, PSWAP, VAL, XOR,
 };
 use frame_support::dispatch::{Pays, PostDispatchInfo};
 use frame_support::traits::Hooks;
@@ -41,7 +41,7 @@ use frame_system::pallet_prelude::BlockNumberFor;
 use framenode_chain_spec::ext;
 use framenode_runtime::qa_tools;
 use framenode_runtime::{Runtime, RuntimeOrigin};
-use order_book::{DataLayer, LimitOrder, MomentOf, OrderBookId, OrderPrice, OrderVolume};
+use order_book::{DataLayer, LimitOrder, MomentOf, OrderPrice, OrderVolume};
 use qa_tools::{pallet_tools, Error};
 use sp_runtime::traits::BadOrigin;
 use sp_runtime::DispatchErrorWithPostInfo;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2528,6 +2528,7 @@ parameter_types! {
 impl presto::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type TradingPairSourceManager = trading_pair::Pallet<Runtime>;
+    type OrderBookManager = OrderBook;
     type PrestoUsdAssetId = PrestoUsdAssetId;
     type PrestoTechAccount = PrestoTechAccountId;
     type PrestoBufferTechAccount = PrestoBufferTechAccountId;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2527,11 +2527,13 @@ parameter_types! {
 #[cfg(feature = "wip")] // presto
 impl presto::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type TradingPairSourceManager = trading_pair::Pallet<Runtime>;
     type PrestoUsdAssetId = PrestoUsdAssetId;
     type PrestoTechAccount = PrestoTechAccountId;
     type PrestoBufferTechAccount = PrestoBufferTechAccountId;
     type RequestId = u64;
     type CropReceiptId = u64;
+    type CouponId = u64;
     type MaxPrestoManagersCount = ConstU32<100>;
     type MaxPrestoAuditorsCount = ConstU32<100>;
     type MaxUserRequestCount = ConstU32<65536>;

--- a/runtime/src/tests/xor_fee.rs
+++ b/runtime/src/tests/xor_fee.rs
@@ -29,7 +29,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mock::{ensure_pool_initialized, fill_spot_price};
-use crate::order_book::OrderBookId;
 use crate::xor_fee_impls::{CustomFeeDetails, CustomFees};
 use crate::{
     AccountId, AssetId, Assets, Balance, Balances, Currencies, FeeKusdBurnedWeight,
@@ -44,9 +43,8 @@ use common::prelude::{AssetName, AssetSymbol, FixedWrapper, SwapAmount};
 use common::XykPool;
 use common::{
     assert_approx_eq_abs, balance, fixed_wrapper, AssetInfoProvider, DEXId, FilterMode,
-    PriceVariant, TBCD, VAL, XOR,
+    OrderBookId, PriceVariant, DOT, KUSD, TBCD, VAL, XOR,
 };
-use common::{DOT, KUSD};
 use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};
 use frame_support::pallet_prelude::{InvalidTransaction, Pays};
 use frame_support::traits::{OnFinalize, OnInitialize};


### PR DESCRIPTION
When Crop Receipt is published:
- Register & mint new Coupon asset
- Transer Coupons to CR owner
- Register Coupon/PRUSD trading pair
- Create Coupon/PRSUD order book
- Place all Coupons in order book on behalf of CR owner