### PR TITLE
refactor: set on-chain election fallback

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -774,12 +774,7 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
     type OffchainRepeat = OffchainRepeat;
     type MinerTxPriority = NposSolutionPriority;
     type DataProvider = Staking;
-    type Fallback = frame_election_provider_support::NoElection<(
-        AccountId,
-        BlockNumber,
-        Staking,
-        MaxActiveValidators,
-    )>;
+    type Fallback = onchain::OnChainExecution<OnChainSeqPhragmen>;
     type GovernanceFallback = onchain::OnChainExecution<OnChainSeqPhragmen>;
     type Solver = SequentialPhragmen<
         AccountId,


### PR DESCRIPTION
This PR sets `Fallback` for `pallet_election_provider_multi_phase` to on-chain election (same as for `GovernanceFallback`). As per @vovac12, this is supposed to solve the eras issue (which are not switching automatically due to failing election fallback).

